### PR TITLE
add --tp-carrier, refactor as needed

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -70,7 +70,7 @@ func doExec(cmd *cobra.Command, args []string) {
 	// pass the existing env but add the latest TRACEPARENT carrier so e.g.
 	// otel-cli exec 'otel-cli exec sleep 1' will relate the spans automatically
 	child.Env = os.Environ()
-	if !ignoreTraceparentEnv {
+	if !traceparentIgnoreEnv {
 		child.Env = append(child.Env, fmt.Sprintf("TRACEPARENT=%s", getTraceparent(ctx)))
 	}
 
@@ -86,5 +86,5 @@ func doExec(cmd *cobra.Command, args []string) {
 	// set the global exit code so main() can grab it and os.Exit() properly
 	exitCode = child.ProcessState.ExitCode()
 
-	printSpanStdout(ctx, span)
+	finishOtelCliSpan(ctx, span)
 }

--- a/cmd/otelclicarrier_test.go
+++ b/cmd/otelclicarrier_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLoadTraceparent(t *testing.T) {
+	file := "/dev/null"
+	ctx := context.Background()
+
+	// TODO:
+	//    * set env, see if it comes through
+	//    * set env and file, make sure the right one comes out
+	//    * clear env, set file, check
+	// etc
+	loadTraceparent(ctx, file)
+}

--- a/cmd/plumbing.go
+++ b/cmd/plumbing.go
@@ -36,7 +36,7 @@ func initTracer() (context.Context, func()) {
 	}
 
 	// set the service name that will show up in tracing UIs
-	resAttrs := resource.WithAttributes(semconv.ServiceNameKey.String(appName))
+	resAttrs := resource.WithAttributes(semconv.ServiceNameKey.String(serviceName))
 	res, err := resource.New(ctx, resAttrs)
 	if err != nil {
 		log.Fatalf("failed to create OpenTelemetry service name resource: %s", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,18 +1,13 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
-var cfgFile, appName, spanName, spanKind string
+var serviceName, spanName, spanKind, traceparentCarrierFile string
 var spanAttrs map[string]string
-var ignoreTraceparentEnv, printTraceparent, printTraceparentExport bool
+var traceparentIgnoreEnv, traceparentPrint, traceparentPrintExport bool
+var traceparentCarrierRequired bool
 var exitCode int
 
 // rootCmd represents the base command when called without any subcommands
@@ -31,58 +26,21 @@ func Execute() {
 func init() {
 	spanAttrs = make(map[string]string)
 	cobra.EnableCommandSorting = false
-	cobra.OnInitialize(initConfig)
-
 	rootCmd.Flags().SortFlags = false
 
-	// global parameters
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.otel-cli.yaml)")
 	// TODO: put in global flags for the otel endpoint and stuff like that here
-
-	rootCmd.PersistentFlags().StringVarP(&appName, "service-name", "n", "otel-cli", "set the name of the application sent on the traces")
-	// TODO: probably want to bind this to viper? seems handy...
+	rootCmd.PersistentFlags().StringVarP(&serviceName, "service-name", "n", "otel-cli", "set the name of the application sent on the traces")
 
 	// all commands and subcommands accept attributes, some might ignore
 	// e.g. `--attrs "foo=bar,baz=inga"`
 	rootCmd.PersistentFlags().StringToStringVarP(&spanAttrs, "attrs", "a", map[string]string{}, "a comma-separated list of key=value attributes")
-	// TODO: this is just a guess for now
-	viperBindFlag("otel-cli.attributes", rootCmd.PersistentFlags().Lookup("attrs"))
 
 	rootCmd.PersistentFlags().StringVarP(&spanKind, "kind", "k", "client", "set the trace kind, e.g. internal, server, client, producer, consumer")
 
-	rootCmd.PersistentFlags().BoolVar(&ignoreTraceparentEnv, "ignore-tp-env", false, "ignore the TRACEPARENT envvar even if it's set")
-
-	rootCmd.PersistentFlags().BoolVar(&printTraceparent, "print-tp", false, "print the trace id, span id, and the w3c-formatted traceparent representation of the new span")
-	rootCmd.PersistentFlags().BoolVarP(&printTraceparentExport, "print-tp-export", "p", false, "same as --print-tp but it puts an 'export ' in front so it's more convinenient to source in scripts")
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".otel-cli" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".otel-cli")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
-}
-
-// viperBindFlag provides a wrapper around the viper bindings that handles error checks
-func viperBindFlag(name string, flag *pflag.Flag) {
-	err := viper.BindPFlag(name, flag)
-	if err != nil {
-		panic(err)
-	}
+	rootCmd.PersistentFlags().StringVar(&traceparentCarrierFile, "tp-carrier", "", "a file for reading and WRITING traceparent across invocations")
+	rootCmd.PersistentFlags().BoolVar(&traceparentCarrierRequired, "tp-carrier-required", false, "when set to true, fail and log when the carrier file doesn't already exist or TRACEPARENT isn't in the environment")
+	rootCmd.PersistentFlags().BoolVar(&traceparentIgnoreEnv, "tp-ignore-env", false, "ignore the TRACEPARENT envvar even if it's set")
+	rootCmd.PersistentFlags().BoolVar(&traceparentPrint, "tp-print", false, "print the trace id, span id, and the w3c-formatted traceparent representation of the new span")
+	// TOOD: probably remove this
+	rootCmd.PersistentFlags().BoolVarP(&traceparentPrintExport, "tp-export", "p", false, "same as --tp-print but it puts an 'export ' in front so it's more convinenient to source in scripts")
 }

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -23,7 +23,7 @@ Example:
 		--start 2021-03-24T07:28:05.12345Z \
 		--end $(date +%s.%N) \
 		--attrs "os.kernel=$(uname -r)" \
-		--print-traceparent
+		--tp-print
 `,
 	Run: doSpan,
 }
@@ -63,12 +63,12 @@ func doSpan(cmd *cobra.Command, args []string) {
 
 	ctx, shutdown := initTracer()
 	defer shutdown()
-	ctx = loadTraceparentFromEnv(ctx)
+	ctx = loadTraceparent(ctx, traceparentCarrierFile)
 	tracer := otel.Tracer("otel-cli/span")
 
 	ctx, span := tracer.Start(ctx, spanName, startOpts...)
 	span.SetAttributes(cliAttrsToOtel(spanAttrs)...) // applies CLI attributes to the span
 	span.End(endOpts...)
 
-	printSpanStdout(ctx, span)
+	finishOtelCliSpan(ctx, span)
 }

--- a/demos/01-simple-span.sh
+++ b/demos/01-simple-span.sh
@@ -15,7 +15,7 @@ et=$(date +%s.%N)
 	--kind         "client"      \
 	--start        $st           \
 	--end          $et           \
-	--print-tp                   \
+	--tp-print                   \
 	--attrs "my.data1=$data1,my.data2=$data2"
 
 cat >/dev/null<<EOF

--- a/demos/05-nested-exec.sh
+++ b/demos/05-nested-exec.sh
@@ -7,14 +7,14 @@
 
 # generate a new trace & span, cli will print out the 'export TRACEPARENT'
 carrier=$(mktemp)
-../otel-cli span -s $0 -n "traceparent demo" -p |tee $carrier
-source $carrier # sets TRACEPARENT (todo - this is not entirely safe)
+../otel-cli span -s $0 -n "traceparent demo" --tp-print --tp-carrier $carrier
 
 # this will start a child span, and run another otel-cli as its program
 ../otel-cli exec \
 	--service-name "fake-client" \
 	--span-name    "hammer the server for sweet sweet data" \
 	--kind         "client" \
+	--tp-carrier   $carrier \
 	"../otel-cli exec -n fake-server -s 'put up with the clients nonsense' -k server echo 500 NOPE"
 	# ^ child span, the responding "server" that just echos NOPE
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,7 @@ module github.com/packethost/otel-cli
 go 1.14
 
 require (
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.1.3
-	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.7.0
 	go.opentelemetry.io/otel v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp v0.19.0
 	go.opentelemetry.io/otel/sdk v0.19.0


### PR DESCRIPTION
c=$(mktemp)
otel-cli span --tp-carrier $c

also dropped the unused viper code for now

renamed cli options & variables to make them more consistent, so now all
the traceparent options start with --tp

renamed functions to be a little clearer

started a test file for otelclicarrier - still needs lots of work

go mod tidy