### PR TITLE
simplify name parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ go build
 
 ```shell
 # run a program inside a span
-otel-cli exec --service-name my-service --span-name "curl google" curl https://google.com
+otel-cli exec --service my-service --name "curl google" curl https://google.com
 
 # otel-cli propagates span parents via envvars so you can chain it to create spans
 otel-cli exec --kind producer "otel-cli exec --kind consumer sleep 1"
@@ -51,11 +51,11 @@ otel-cli span -n my-script -s some-interesting-program --start $start --end $end
 # add events to it, finally closing it later in your script
 sockdir=$(mktemp -d)
 otel-cli span background \
-   --service-name $0           \
-   --span-name "$0 runtime"    \
+   --service $0          \
+   --name "$0 runtime"   \
    --sockdir $sockdir & # the & is important here, background server will block
 sleep 0.1 # give the background server just a few ms to start up
-otel-cli span event --event-name "cool thing" --attrs "foo=bar" --sockdir $sockdir
+otel-cli span event --name "cool thing" --attrs "foo=bar" --sockdir $sockdir
 otel-cli span end --sockdir $sockdir
 # or you can kill the background process and it will end the span cleanly
 kill %1

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -23,7 +23,7 @@ passed to the child process's environment as TRACEPARENT.
 
 Examples:
 
-otel-cli exec --name my-cool-thing --span interesting-step curl https://cool-service/api/v1/endpoint
+otel-cli exec -n my-cool-thing -s interesting-step curl https://cool-service/api/v1/endpoint
 
 otel-cli exec -s "outer span" 'otel-cli exec -s "inner span" sleep 1'
 
@@ -36,8 +36,8 @@ to sh -c and should not be passed any untrusted input`,
 func init() {
 	rootCmd.AddCommand(execCmd)
 
-	// --span-name / -s, see span.go
-	execCmd.Flags().StringVarP(&spanName, "span-name", "s", "todo-generate-default-span-names", "set the name of the span")
+	// --name / -s, see span.go
+	execCmd.Flags().StringVarP(&spanName, "name", "s", "todo-generate-default-span-names", "set the name of the span")
 }
 
 func doExec(cmd *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ func init() {
 	rootCmd.Flags().SortFlags = false
 
 	// TODO: put in global flags for the otel endpoint and stuff like that here
-	rootCmd.PersistentFlags().StringVarP(&serviceName, "service-name", "n", "otel-cli", "set the name of the application sent on the traces")
+	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "n", "otel-cli", "set the name of the application sent on the traces")
 
 	// all commands and subcommands accept attributes, some might ignore
 	// e.g. `--attrs "foo=bar,baz=inga"`

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -19,8 +19,8 @@ with support for nanoseconds on both.
 
 Example:
 	otel-cli span \
-		--system-name "my-application" \
-		--span-name "send data to the server" \
+		--system "my-application" \
+		--name "send data to the server" \
 		--start 2021-03-24T07:28:05.12345Z \
 		--end $(date +%s.%N) \
 		--attrs "os.kernel=$(uname -r)" \
@@ -36,8 +36,8 @@ func init() {
 	rootCmd.AddCommand(spanCmd)
 	spanCmd.Flags().SortFlags = false
 
-	// --span-name / -s
-	spanCmd.PersistentFlags().StringVarP(&spanName, "span-name", "s", "todo-generate-default-span-names", "set the name of the span")
+	// --name / -s
+	spanCmd.PersistentFlags().StringVarP(&spanName, "name", "s", "todo-generate-default-span-names", "set the name of the span")
 
 	// --start $timestamp (RFC3339 or Unix_Epoch.Nanos)
 	spanCmd.Flags().StringVar(&spanStartTime, "start", "", "a Unix epoch or RFC3339 timestamp for the start of the span")

--- a/cmd/span_background.go
+++ b/cmd/span_background.go
@@ -27,15 +27,15 @@ timeout, (catchable) signals, or deliberate exit.
 
     socket_dir=$(mktemp -d)
 	otel-cli span background \
-		--system-name "my-long-script.sh" \
-		--span-name "run the script" \
+		--system "my-long-script.sh" \
+		--name "run the script" \
 		--attrs "os.kernel=$(uname -r)" \
 		--timeout 60 \
 		--sockdir $socket_dir & # <-- notice the &
 	
 	otel-cli span event \
 		--sockdir $socket_dir \
-		--event-name "something interesting happened!" \
+		--name "something interesting happened!" \
 		--attrs "foo=bar"
 `,
 	Run: doSpanBackground,

--- a/cmd/span_event.go
+++ b/cmd/span_event.go
@@ -19,7 +19,7 @@ See: otel-cli span background
 
 	otel-cli span event \
 	    --sockdir $sockdir \
-		--event-name "did a cool thing" \
+		--name "did a cool thing" \
 		--time $(date +%s.%N) \
 		--attrs "os.kernel=$(uname -r)"
 `,
@@ -30,8 +30,8 @@ func init() {
 	spanCmd.AddCommand(spanEventCmd)
 	spanEventCmd.Flags().SortFlags = false
 
-	// --event-name / -e
-	spanEventCmd.Flags().StringVarP(&spanEventName, "event-name", "e", "todo-generate-default-event-names", "set the name of the event")
+	// --name / -n
+	spanEventCmd.Flags().StringVarP(&spanEventName, "name", "e", "todo-generate-default-event-names", "set the name of the event")
 
 	// --time / -t
 	spanEventCmd.Flags().StringVarP(&spanEventTime, "time", "t", "now", "the precise time of the event in RFC3339Nano or Unix.nano format")

--- a/demos/01-simple-span.sh
+++ b/demos/01-simple-span.sh
@@ -10,35 +10,10 @@ et=$(date +%s.%N)
 
 # don't worry, there are also short options :)
 ../otel-cli span \
-	--service-name "demo.sh"     \
-	--span-name    "hello world" \
-	--kind         "client"      \
-	--start        $st           \
-	--end          $et           \
-	--tp-print                   \
+	--service  "demo.sh"     \
+	--name     "hello world" \
+	--kind     "client"      \
+	--start    $st           \
+	--end      $et           \
+	--tp-print               \
 	--attrs "my.data1=$data1,my.data2=$data2"
-
-cat >/dev/null<<EOF
-A command-line interface for generating OpenTelemetry data on the command line.
-
-Usage:
-  otel-cli [command]
-
-Available Commands:
-  exec        execute the command provided
-  span        create an OpenTelemetry span and send it
-  help        Help about any command
-
-Flags:
-  -a, --attrs stringToString   a comma-separated list of key=value attributes (default [])
-  -c, --config string          config file (default is $HOME/.otel-cli.yaml)
-      --ignore-tp-env          ignore the TRACEPARENT envvar even if it's set
-  -k, --kind string            set the trace kind, e.g. internal, server, client, producer, consumer (default "client")
-  -p, --print-span             print the trace id, span id, and the w3c-formatted traceparent representation of the new span
-  -n, --service-name string    set the name of the application sent on the traces (default "otel-cli")
-  -s, --span-name string       set the name of the application sent on the traces (default "todo-generate-default-span-names")
-  -h, --help                   help for otel-cli
-
-Use "otel-cli [command] --help" for more information about a command.
-EOF
-

--- a/demos/05-nested-exec.sh
+++ b/demos/05-nested-exec.sh
@@ -11,10 +11,10 @@ carrier=$(mktemp)
 
 # this will start a child span, and run another otel-cli as its program
 ../otel-cli exec \
-	--service-name "fake-client" \
-	--span-name    "hammer the server for sweet sweet data" \
-	--kind         "client" \
-	--tp-carrier   $carrier \
+	--service    "fake-client" \
+	--name       "hammer the server for sweet sweet data" \
+	--kind       "client" \
+	--tp-carrier $carrier \
 	"../otel-cli exec -n fake-server -s 'put up with the clients nonsense' -k server echo 500 NOPE"
 	# ^ child span, the responding "server" that just echos NOPE
 


### PR DESCRIPTION
simplify -service-name, --span-name, and --event-name

--span-name and --event-name are now both just --name

--service-name is now just --service

update docs

cleaned up some junk too