### PR TITLE
Feature: Add span status config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ also be configured via file or environment variables.
 | --tp-ignore-env | OTEL_CLI_IGNORE_ENV           | tp-ignore-env   | false          |
 | --tp-print      | OTEL_CLI_PRINT_TRACEPARENT    | tp-print        | false          |
 | --tp-export     | OTEL_CLI_EXPORT_TRACEPARENT   | tp-export       | false          |
+| --status        | OTEL_CLI_SPAN_STATUS          | status          | false          |
 
 ## Easy local dev
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 // TODO: that's a lot of globals, maybe move this into a struct
 var cfgFile, serviceName, spanName, spanKind, traceparentCarrierFile string
 var spanAttrs, otlpHeaders map[string]string
+var spanStatus bool
 var otlpEndpoint string
 var otlpInsecure, otlpBlocking bool
 var traceparentIgnoreEnv, traceparentPrint, traceparentPrintExport bool
@@ -30,6 +31,7 @@ func Execute() {
 
 func init() {
 	spanAttrs = make(map[string]string)
+	spanStatus = false
 	otlpHeaders = make(map[string]string)
 	cobra.OnInitialize(initViperConfig)
 	cobra.EnableCommandSorting = false
@@ -69,6 +71,10 @@ func init() {
 	rootCmd.PersistentFlags().StringToStringVarP(&spanAttrs, "attrs", "a", map[string]string{}, "a comma-separated list of key=value attributes")
 	viper.BindPFlag("attrs", rootCmd.PersistentFlags().Lookup("attrs"))
 	viper.BindEnv("OTEL_CLI_ATTRIBUTES", "attrs")
+
+	rootCmd.PersistentFlags().StringToStringVarP(&spanStatus, "status", "s", false, "when set to true, mark span status as Error")
+	viper.BindPFlag("status", rootCmd.PersistentFlags().Lookup("status"))
+	viper.BindEnv("OTEL_SPAN_STATUS", "status")
 
 	// trace propagation options
 	rootCmd.PersistentFlags().BoolVar(&traceparentRequired, "tp-required", false, "when set to true, fail and log if a traceparent can't be picked up from TRACEPARENT ennvar or a carrier file")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVarP(&spanStatus, "status", "s", false, "when set to true, mark span status as Error")
 	viper.BindPFlag("status", rootCmd.PersistentFlags().Lookup("status"))
-	viper.BindEnv("OTEL_SPAN_STATUS", "status")
+	viper.BindEnv("OTEL_CLI_SPAN_STATUS", "status")
 
 	// trace propagation options
 	rootCmd.PersistentFlags().BoolVar(&traceparentRequired, "tp-required", false, "when set to true, fail and log if a traceparent can't be picked up from TRACEPARENT ennvar or a carrier file")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ func init() {
 	viper.BindPFlag("attrs", rootCmd.PersistentFlags().Lookup("attrs"))
 	viper.BindEnv("OTEL_CLI_ATTRIBUTES", "attrs")
 
-	rootCmd.PersistentFlags().StringToStringVarP(&spanStatus, "status", "s", false, "when set to true, mark span status as Error")
+	rootCmd.PersistentFlags().BoolVarP(&spanStatus, "status", "s", false, "when set to true, mark span status as Error")
 	viper.BindPFlag("status", rootCmd.PersistentFlags().Lookup("status"))
 	viper.BindEnv("OTEL_SPAN_STATUS", "status")
 

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -78,7 +78,6 @@ func startSpan() (context.Context, trace.Span, func()) {
 	if spanStatus == true {
 		span.SetStatus(codes.Error, "error")	
 	}
-	
 
 	return ctx, span, shutdown
 }

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"regexp"
 
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -73,6 +75,10 @@ func startSpan() (context.Context, trace.Span, func()) {
 
 	ctx, span := tracer.Start(ctx, spanName, startOpts...)
 	span.SetAttributes(cliAttrsToOtel(spanAttrs)...) // applies CLI attributes to the span
+
+	// span.SetStatus(cliAttrsToOtel(spanAttrs)...) // applies CLI attributes to the span
+
+	span.SetStatus(codes.Error, fmt.Sprintf("command failed: %s", "testMsg"))
 
 	return ctx, span, shutdown
 }

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"regexp"
 
@@ -76,9 +75,10 @@ func startSpan() (context.Context, trace.Span, func()) {
 	ctx, span := tracer.Start(ctx, spanName, startOpts...)
 	span.SetAttributes(cliAttrsToOtel(spanAttrs)...) // applies CLI attributes to the span
 
-	// span.SetStatus(cliAttrsToOtel(spanAttrs)...) // applies CLI attributes to the span
-
-	span.SetStatus(codes.Error, fmt.Sprintf("command failed: %s", "testMsg"))
+	if spanStatus == true {
+		span.SetStatus(codes.Error, "error")	
+	}
+	
 
 	return ctx, span, shutdown
 }


### PR DESCRIPTION
Hello friends, this PR adds a `--status` option so users can mark spans as `error/exceptions`. I found myself reaching for this functionality when trying to test the behavior of otlp receivers for spans that have span.events named `exception`, As right now the only way to mark a span status as an `error` is to wrap a command that itself fails.

Implementation is a bit hacky imo but i wasn't sure how y'all would prefer this so figured i'd make the PR for the purposes of discussion. I was thinking maybe `--status` , instead of being a `bool` could be an optional `string` and if set, then mark the span as an error/exception, and add the `--status` value as the span status description? 