### PR TITLE
move from packethost org to github.com/equinix-labs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
       - darwin
 nfpms:
   - package_name: otel-cli
-    homepage: https://github.com/packethost/otel-cli
+    homepage: https://github.com/equinix-labs/otel-cli
     description: OpenTelemetry CLI Application (Server & Client)
     license: Apache 2.0
     file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Arch}}"

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ program too much and you don't spam outbound connections on each command.
 The easiest way is a go get:
 
 ```shell
-go get github.com/packethost/otel-cli
+go get github.com/equinix-labs/otel-cli
 ```
 
 Alternatively, clone the repo and build it locally:
 
 ```shell
-git clone git@github.com:packethost/otel-cli.git
+git clone git@github.com:equinix-labs/otel-cli.git
 cd otel-cli
 go build
 ```
@@ -110,7 +110,7 @@ README. However, the good news is that it's fairly easy to do! You can follow th
 
 If you're planning on making changes to otel-cli, we recommend building the project locally: `go build`
 
-But, if you just want to quickly try out otel-cli, you can also just install it directly: `go get github.com/packethost/otel-cli`. This will place the command in your `GOPATH`. If your `GOPATH` is in your `PATH` you should be all set.
+But, if you just want to quickly try out otel-cli, you can also just install it directly: `go get github.com/equinix-labs/otel-cli`. This will place the command in your `GOPATH`. If your `GOPATH` is in your `PATH` you should be all set.
 
 ### 3. A system to receive/inspect the traces you generate
 
@@ -189,7 +189,7 @@ go run . span -n "testing" -s "my first test span"
 
 ## Contributing
 
-Please file issues and PRs on the GitHub project at https://github.com/packethost/otel-cli
+Please file issues and PRs on the GitHub project at https://github.com/equinix-labs/otel-cli
 
 ## Releases
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/packethost/otel-cli
+module github.com/equinix-labs/otel-cli
 
 go 1.14
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/packethost/otel-cli v0.0.3
 	github.com/pterm/pterm v0.12.30
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/packethost/otel-cli v0.0.3
 	github.com/pterm/pterm v0.12.30
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/packethost/otel-cli v0.0.3 h1:+8HPDPNmvc1wIdvz0J5n7za2l9MnAHJjZKZ4mtNG9A8=
-github.com/packethost/otel-cli v0.0.3/go.mod h1:B6kiA3V2p+kTGrVmwNQhF/tUNT3Rkzj9Y+F7dht4cpQ=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/packethost/otel-cli v0.0.3 h1:+8HPDPNmvc1wIdvz0J5n7za2l9MnAHJjZKZ4mtNG9A8=
+github.com/packethost/otel-cli v0.0.3/go.mod h1:B6kiA3V2p+kTGrVmwNQhF/tUNT3Rkzj9Y+F7dht4cpQ=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/packethost/otel-cli/cmd"
+	"github.com/equinix-labs/otel-cli/cmd"
 )
 
 func main() {


### PR DESCRIPTION
finishes off #40 by replacing instances of "packethost" with "equinix-labs"