### PR TITLE
fix goreleaser config & add some ignores

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,25 +39,31 @@ nfpms:
       - rpm
 
 archives:
-  - format: tar.gz
+  - name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    format: tar.gz
     format_overrides:
       - goos: windows
         format: zip
-    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-  - replacements:
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
       386: i386
       amd64: x86_64
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: 'SNAPSHOT-{{ .Commit }}'
+
 changelog:
   sort: asc
   filters:
     exclude:
       - '^demos:'
       - '^configs:'
+      - Merge pull request
+      - Merge branch
+      - go mod tidy
 


### PR DESCRIPTION
I tagged v0.0.4 before noticing a config error in the goreleaser.yaml. Fixed that, and added a couple exceptions to ignore merge commits and 'go mod tidy'.