### PR TITLE
use ghcr.io for otel-cli packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,14 +92,25 @@ dockers:
     dockerfile: release/Dockerfile
     use: buildx
     build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
   - image_templates:
     - "ghcr.io/equinix-labs/otel-cli:v{{ .Version }}-arm64v8"
     dockerfile: release/Dockerfile
     use: buildx
     build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64/v8"
-
 
 docker_manifests:
   - name_template: "equinix/otel-cli:{{ .Version }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,13 +88,13 @@ brews:
 
 dockers:
   - image_templates:
-    - "equinix/otel-cli:v{{ .Version }}-amd64"
+    - "ghcr.io/equinix-labs/otel-cli:v{{ .Version }}-amd64"
     dockerfile: release/Dockerfile
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
   - image_templates:
-    - "equinix/otel-cli:v{{ .Version }}-arm64v8"
+    - "ghcr.io/equinix-labs/otel-cli:v{{ .Version }}-arm64v8"
     dockerfile: release/Dockerfile
     use: buildx
     build_flag_templates:


### PR DESCRIPTION
follow-on for #52 tested a manual push of my failed 0.0.9 release and it worked

still working through GH org permissions but at least I can release now

I might also add the fancy manifest variables? @emattiza do we want the other opencontainer stuff like goreleaser has? 

https://github.com/goreleaser/goreleaser/blob/master/.goreleaser.yml

`docker images inspect ghcr.io/equinix-labs/otel-cli:v0.0.9-arm64v8` doesn't show me any of the manifest tags. I'm still learning here and will keep iterating on it :)