### PR TITLE
Added basic subcommand completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"log"
+	"os"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(otel-cli completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ otel-cli completion bash > /etc/bash_completion.d/otel-cli
+  # macOS:
+  $ otel-cli completion bash > /usr/local/etc/bash_completion.d/otel-cli
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ otel-cli completion zsh > "${fpath[1]}/_otel-cli"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ otel-cli completion fish | source
+
+  # To load completions for each session, execute once:
+  $ otel-cli completion fish > ~/.config/fish/completions/otel-cli.fish
+
+PowerShell:
+
+  PS> otel-cli completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> otel-cli completion powershell > otel-cli.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			err := cmd.Root().GenBashCompletion(os.Stdout)
+			if err != nil {
+				log.Fatalf("failed to write completion to stdout")
+			}
+		case "zsh":
+			err := cmd.Root().GenZshCompletion(os.Stdout)
+			if err != nil {
+				log.Fatalf("failed to write completion to stdout")
+			}
+		case "fish":
+			err := cmd.Root().GenFishCompletion(os.Stdout, true)
+			if err != nil {
+				log.Fatalf("failed to write completion to stdout")
+			}
+		case "powershell":
+			err := cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			if err != nil {
+				log.Fatalf("failed to write completion to stdout")
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
Address #57. Just added the sample shell completion logic, straight copy-paste from cobra/shell_completions.md. Will need to discuss customizing for required flags on all or some subcommands? Whats the mix of env-vars and flags required per command, or omit and discover via help?

Here's some sample pics at root:
![image](https://user-images.githubusercontent.com/11719476/131430460-8a7cacd3-a600-4754-913c-77fcf3f437f7.png)
Under server:
![image](https://user-images.githubusercontent.com/11719476/131430550-87147a3a-70b4-4cc6-b458-dcb6014b4b19.png)
Under span:
![image](https://user-images.githubusercontent.com/11719476/131430605-86172286-759e-41aa-a357-cf9ce9c9c9d0.png)
Under completion (listing valid completion targets):
![image](https://user-images.githubusercontent.com/11719476/131430689-7bc73884-1926-4902-93f5-d5d9520e397d.png)
