### PR TITLE
move most of the config globals into a config struct

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -138,7 +138,7 @@ func GetExitCode() int {
 // propagateOtelCliSpan saves the traceparent to file if necessary, then prints
 // span info to the console according to command-line args.
 func propagateOtelCliSpan(ctx context.Context, span trace.Span, target io.Writer) {
-	saveTraceparentToFile(ctx, traceparentCarrierFile)
+	saveTraceparentToFile(ctx, config.TraceparentCarrierFile)
 
 	tpout := getTraceparent(ctx)
 	tid := span.SpanContext().TraceID().String()
@@ -151,14 +151,14 @@ func propagateOtelCliSpan(ctx context.Context, span trace.Span, target io.Writer
 // depending on which command line arguments were set.
 func printSpanData(target io.Writer, traceId, spanId, tp string) {
 	// --tp-print / --tp-export
-	if !traceparentPrint && !traceparentPrintExport {
+	if !config.TraceparentPrint && !config.TraceparentPrintExport {
 		return
 	}
 
 	// --tp-export will print "export TRACEPARENT" so it's
 	// one less step to print to a file & source, or eval
 	var exported string
-	if traceparentPrintExport {
+	if config.TraceparentPrintExport {
 		exported = "export "
 	}
 
@@ -168,14 +168,14 @@ func printSpanData(target io.Writer, traceId, spanId, tp string) {
 // parseCliTimeout parses the cliTimeout global string value to a time.Duration.
 // It logs an error and returns time.Duration(0) if the string is empty or unparseable.
 func parseCliTimeout() time.Duration {
-	if cliTimeout == "" {
+	if config.Timeout == "" {
 		return time.Duration(0)
 	}
 
-	if d, err := time.ParseDuration(cliTimeout); err == nil {
+	if d, err := time.ParseDuration(config.Timeout); err == nil {
 		return d
 	} else {
-		log.Printf("unable to parse --timeout %q: %s", cliTimeout, err)
+		log.Printf("unable to parse --timeout %q: %s", config.Timeout, err)
 		return time.Duration(0)
 	}
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -168,9 +168,11 @@ func TestPropagateOtelCliSpan(t *testing.T) {
 	// TODO: should this noop the tracing backend?
 
 	// set package globals to a known state
-	traceparentCarrierFile = ""
-	traceparentPrint = false
-	traceparentPrintExport = false
+	config = Config{
+		TraceparentCarrierFile: "",
+		TraceparentPrint:       false,
+		TraceparentPrintExport: false,
+	}
 
 	tp := "00-3433d5ae39bdfee397f44be5146867b3-8a5518f1e5c54d0a-01"
 	tid := "3433d5ae39bdfee397f44be5146867b3"
@@ -187,8 +189,8 @@ func TestPropagateOtelCliSpan(t *testing.T) {
 		t.Errorf("nothing was supposed to be written but %d bytes were", buf.Len())
 	}
 
-	traceparentPrint = true
-	traceparentPrintExport = true
+	config.TraceparentPrint = true
+	config.TraceparentPrintExport = true
 	buf = new(bytes.Buffer)
 	printSpanData(buf, tid, sid, tp)
 	if buf.Len() == 0 {
@@ -230,12 +232,12 @@ func TestParseCliTime(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
-			cliTimeout = testcase.input
+			config = Config{Timeout: testcase.input}
 			got := parseCliTimeout()
 			if got != testcase.expected {
 				ed := testcase.expected.String()
 				gd := got.String()
-				t.Errorf("duration string %q was expected to return %s but returned %s", cliTimeout, ed, gd)
+				t.Errorf("duration string %q was expected to return %s but returned %s", config.Timeout, ed, gd)
 			}
 		})
 	}

--- a/cmd/otelclicarrier.go
+++ b/cmd/otelclicarrier.go
@@ -63,7 +63,7 @@ func loadTraceparent(ctx context.Context, filename string) context.Context {
 	if filename != "" {
 		ctx = loadTraceparentFromFile(ctx, filename)
 	}
-	if traceparentRequired {
+	if config.TraceparentRequired {
 		tp := getTraceparent(ctx) // get the text representation in the context
 		if len(tp) > 0 && checkTracecarrierRe.MatchString(tp) {
 			parts := strings.Split(tp, "-") // e.g. 00-9765b2f71c68b04dc0ad2a4d73027d6f-1881444346b6296e-01
@@ -86,7 +86,7 @@ func loadTraceparentFromFile(ctx context.Context, filename string) context.Conte
 	if err != nil {
 		// only fatal when the tp carrier file is required explicitly, otherwise
 		// just silently return the unmodified context
-		if traceparentRequired {
+		if config.TraceparentRequired {
 			log.Fatalf("could not open file '%s' for read: %s", filename, err)
 		} else {
 			return ctx
@@ -135,7 +135,7 @@ func saveTraceparentToFile(ctx context.Context, filename string) {
 // TRACEPARENT and sets it in the returned Go context.
 func loadTraceparentFromEnv(ctx context.Context) context.Context {
 	// don't load the envvar when --tp-ignore-env is set
-	if traceparentIgnoreEnv {
+	if config.TraceparentIgnoreEnv {
 		return ctx
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,11 +28,21 @@ type Config struct {
 	TraceparentPrintExport bool   `json:"traceparent_print_export"`
 	TraceparentRequired    bool   `json:"traceparent_required"`
 
+	BackgroundParentPollMs int    `json:"background_parent_poll_ms"`
+	BackgroundSockdir      string `json:"background_socket_directory"`
+
+	SpanStartTime string `json:"span_start_time"`
+	SpanEndTime   string `json:"span_end_time"`
+	EventName     string `json:"event_name"`
+	EventTime     string `json:"event_time"`
+
 	CfgFile string `json:"config_file"`
 }
 
+const defaultOtlpEndpoint = "localhost:4317"
+const spanBgSockfilename = "otel-cli-background.sock"
+
 var exitCode int
-var defaultOtlpEndpoint = "localhost:4317"
 var config Config
 
 // rootCmd represents the base command when called without any subcommands
@@ -49,6 +59,7 @@ func Execute() {
 }
 
 func init() {
+
 	cobra.OnInitialize(initViperConfig)
 	cobra.EnableCommandSorting = false
 	rootCmd.Flags().SortFlags = false

--- a/cmd/server_json.go
+++ b/cmd/server_json.go
@@ -50,10 +50,10 @@ func doServerJson(cmd *cobra.Command, args []string) {
 	}
 
 	// unlike the rest of otel-cli, server should default to localhost:4317
-	if otlpEndpoint == "" {
-		otlpEndpoint = defaultOtlpEndpoint
+	if config.Endpoint == "" {
+		config.Endpoint = defaultOtlpEndpoint
 	}
-	cs.ServeGPRC(otlpEndpoint)
+	cs.ServeGPRC(config.Endpoint)
 }
 
 // writeFile takes the spans and events and writes them out to json files in the

--- a/cmd/server_json.go
+++ b/cmd/server_json.go
@@ -17,7 +17,6 @@ var jsonSvr struct {
 	outDir    string
 	stdout    bool
 	maxSpans  int
-	timeout   int
 	spansSeen int
 }
 

--- a/cmd/server_tui.go
+++ b/cmd/server_tui.go
@@ -47,10 +47,10 @@ func doServerTui(cmd *cobra.Command, args []string) {
 	cs := otlpserver.NewServer(renderTui, stop)
 
 	// unlike the rest of otel-cli, server should default to localhost:4317
-	if otlpEndpoint == "" {
-		otlpEndpoint = defaultOtlpEndpoint
+	if config.Endpoint == "" {
+		config.Endpoint = defaultOtlpEndpoint
 	}
-	cs.ServeGPRC(otlpEndpoint)
+	cs.ServeGPRC(config.Endpoint)
 }
 
 // renderTui takes the given span and events, appends them to the in-memory

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -30,7 +30,6 @@ Example:
 	Run: doSpan,
 }
 
-var spanStartTime, spanEndTime string
 var epochNanoTimeRE *regexp.Regexp
 
 func init() {
@@ -38,10 +37,10 @@ func init() {
 	spanCmd.Flags().SortFlags = false
 
 	// --start $timestamp (RFC3339 or Unix_Epoch.Nanos)
-	spanCmd.Flags().StringVar(&spanStartTime, "start", "", "a Unix epoch or RFC3339 timestamp for the start of the span")
+	spanCmd.Flags().StringVar(&config.SpanStartTime, "start", "", "a Unix epoch or RFC3339 timestamp for the start of the span")
 
 	// --end $timestamp
-	spanCmd.Flags().StringVar(&spanEndTime, "end", "", "an Unix epoch or RFC3339 timestamp for the end of the span")
+	spanCmd.Flags().StringVar(&config.SpanEndTime, "end", "", "an Unix epoch or RFC3339 timestamp for the end of the span")
 
 	addCommonParams(spanCmd)
 	addSpanParams(spanCmd)
@@ -64,8 +63,8 @@ func doSpan(cmd *cobra.Command, args []string) {
 func startSpan() (context.Context, trace.Span, func()) {
 	startOpts := []trace.SpanStartOption{trace.WithSpanKind(otelSpanKind(config.Kind))}
 
-	if spanStartTime != "" {
-		t := parseTime(spanStartTime, "start")
+	if config.SpanStartTime != "" {
+		t := parseTime(config.SpanStartTime, "start")
 		startOpts = append(startOpts, trace.WithTimestamp(t))
 	}
 
@@ -83,8 +82,8 @@ func startSpan() (context.Context, trace.Span, func()) {
 func endSpan(span trace.Span) {
 	endOpts := []trace.SpanEndOption{}
 
-	if spanEndTime != "" {
-		t := parseTime(spanEndTime, "end")
+	if config.SpanEndTime != "" {
+		t := parseTime(config.SpanEndTime, "end")
 		endOpts = append(endOpts, trace.WithTimestamp(t))
 	}
 

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -62,7 +62,7 @@ func doSpan(cmd *cobra.Command, args []string) {
 // context, the span, and a deferrable function for clean shutdown (it ends the
 // span).
 func startSpan() (context.Context, trace.Span, func()) {
-	startOpts := []trace.SpanStartOption{trace.WithSpanKind(otelSpanKind(spanKind))}
+	startOpts := []trace.SpanStartOption{trace.WithSpanKind(otelSpanKind(config.Kind))}
 
 	if spanStartTime != "" {
 		t := parseTime(spanStartTime, "start")
@@ -70,11 +70,11 @@ func startSpan() (context.Context, trace.Span, func()) {
 	}
 
 	ctx, shutdown := initTracer()
-	ctx = loadTraceparent(ctx, traceparentCarrierFile)
+	ctx = loadTraceparent(ctx, config.TraceparentCarrierFile)
 	tracer := otel.Tracer("otel-cli/span")
 
-	ctx, span := tracer.Start(ctx, spanName, startOpts...)
-	span.SetAttributes(cliAttrsToOtel(spanAttrs)...) // applies CLI attributes to the span
+	ctx, span := tracer.Start(ctx, config.SpanName, startOpts...)
+	span.SetAttributes(cliAttrsToOtel(config.Attributes)...) // applies CLI attributes to the span
 
 	return ctx, span, shutdown
 }

--- a/cmd/span_background.go
+++ b/cmd/span_background.go
@@ -12,12 +12,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const spanBgSockfilename = "otel-cli-background.sock"
-const spanBgParentPollMs = 10 // check parent pid every 10ms
-
-var spanBgSockdir string
-var spanBgStarted time.Time // for measuring uptime
-
 // spanBgCmd represents the span background command
 var spanBgCmd = &cobra.Command{
 	Use:   "background",
@@ -43,8 +37,9 @@ timeout, (catchable) signals, or deliberate exit.
 }
 
 func init() {
-	// mark the time when the process started for putting uptime in attributes
-	spanBgStarted = time.Now()
+	// this used to be a global const but now it's in Config
+	// TODO: does it make sense to make this configurable? 10ms might be too frequent...
+	config.BackgroundParentPollMs = 10
 
 	spanCmd.AddCommand(spanBgCmd)
 	spanBgCmd.Flags().SortFlags = false
@@ -52,7 +47,7 @@ func init() {
 	// only necessary for adding events to the span. it should be fine to
 	// start a background span at the top of a script then let it fall off
 	// at the end to get an easy span
-	spanBgCmd.Flags().StringVar(&spanBgSockdir, "sockdir", "", "a directory where a socket can be placed safely")
+	spanBgCmd.Flags().StringVar(&config.BackgroundSockdir, "sockdir", "", "a directory where a socket can be placed safely")
 
 	addCommonParams(spanBgCmd)
 	addSpanParams(spanBgCmd)
@@ -62,7 +57,7 @@ func init() {
 // spanBgSockfile returns the full filename for the socket file under the
 // provided background socket directory provided by the user.
 func spanBgSockfile() string {
-	return path.Join(spanBgSockdir, spanBgSockfilename)
+	return path.Join(config.BackgroundSockdir, spanBgSockfilename)
 }
 
 func doSpanBackground(cmd *cobra.Command, args []string) {
@@ -92,7 +87,7 @@ func doSpanBackground(cmd *cobra.Command, args []string) {
 	ppid := os.Getppid()
 	go func() {
 		for {
-			time.Sleep(time.Duration(spanBgParentPollMs) * time.Millisecond)
+			time.Sleep(time.Duration(config.BackgroundParentPollMs) * time.Millisecond)
 
 			// check if the parent process has changed, exit when it does
 			cppid := os.Getppid()
@@ -122,9 +117,7 @@ func doSpanBackground(cmd *cobra.Command, args []string) {
 // spanBgEndEvent adds an event with the provided name, to the provided span
 // with uptime.milliseconds and timeout.seconds attributes.
 func spanBgEndEvent(name string, span trace.Span) {
-	uptime := time.Since(spanBgStarted)
 	attrs := trace.WithAttributes([]attribute.KeyValue{
-		{Key: attribute.Key("uptime.milliseconds"), Value: attribute.Int64Value(uptime.Milliseconds())},
 		{Key: attribute.Key("timeout.duration"), Value: attribute.StringValue(config.Timeout)},
 	}...)
 	span.AddEvent(name, attrs)

--- a/cmd/span_background.go
+++ b/cmd/span_background.go
@@ -125,7 +125,7 @@ func spanBgEndEvent(name string, span trace.Span) {
 	uptime := time.Since(spanBgStarted)
 	attrs := trace.WithAttributes([]attribute.KeyValue{
 		{Key: attribute.Key("uptime.milliseconds"), Value: attribute.Int64Value(uptime.Milliseconds())},
-		{Key: attribute.Key("timeout.duration"), Value: attribute.StringValue(cliTimeout)},
+		{Key: attribute.Key("timeout.duration"), Value: attribute.StringValue(config.Timeout)},
 	}...)
 	span.AddEvent(name, attrs)
 }

--- a/cmd/span_background_server.go
+++ b/cmd/span_background_server.go
@@ -169,7 +169,7 @@ func createBgClient() (*rpc.Client, func()) {
 	sock := net.UnixAddr{Name: sockfile, Net: "unix"}
 	conn, err := net.DialUnix(sock.Net, nil, &sock)
 	if err != nil {
-		log.Fatalf("unable to connect to span background server at '%s': %s", spanBgSockdir, err)
+		log.Fatalf("unable to connect to span background server at '%s': %s", config.BackgroundSockdir, err)
 	}
 
 	return jsonrpc.NewClient(conn), func() { conn.Close() }

--- a/cmd/span_background_server.go
+++ b/cmd/span_background_server.go
@@ -162,7 +162,7 @@ func createBgClient() (*rpc.Client, func()) {
 
 		to := parseCliTimeout()
 		if to > 0 && time.Since(started) > to {
-			log.Fatalf("timeout after %s while waiting for span background socket '%s' to appear", cliTimeout, sockfile)
+			log.Fatalf("timeout after %s while waiting for span background socket '%s' to appear", config.Timeout, sockfile)
 		}
 	}
 

--- a/cmd/span_end.go
+++ b/cmd/span_end.go
@@ -22,7 +22,7 @@ See: otel-cli span background
 
 func init() {
 	spanCmd.AddCommand(spanEndCmd)
-	spanEndCmd.Flags().StringVar(&spanBgSockdir, "sockdir", "", "a directory where a socket can be placed safely")
+	spanEndCmd.Flags().StringVar(&config.BackgroundSockdir, "sockdir", "", "a directory where a socket can be placed safely")
 	spanEndCmd.MarkFlagRequired("sockdir")
 }
 

--- a/cmd/span_event.go
+++ b/cmd/span_event.go
@@ -46,7 +46,7 @@ func doSpanEvent(cmd *cobra.Command, args []string) {
 	rpcArgs := BgSpanEvent{
 		Name:       spanEventName,
 		Timestamp:  timestamp.Format(time.RFC3339Nano),
-		Attributes: spanAttrs,
+		Attributes: config.Attributes,
 	}
 
 	res := BgSpan{}

--- a/cmd/span_event.go
+++ b/cmd/span_event.go
@@ -8,8 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var spanEventName, spanEventTime string
-
 // spanEventCmd represents the span event command
 var spanEventCmd = &cobra.Command{
 	Use:   "event",
@@ -33,18 +31,18 @@ func init() {
 	spanCmd.AddCommand(spanEventCmd)
 	spanEventCmd.Flags().SortFlags = false
 
-	spanEventCmd.Flags().StringVarP(&spanEventName, "name", "e", "todo-generate-default-event-names", "set the name of the event")
-	spanEventCmd.Flags().StringVarP(&spanEventTime, "time", "t", "now", "the precise time of the event in RFC3339Nano or Unix.nano format")
-	spanEventCmd.Flags().StringVar(&spanBgSockdir, "sockdir", "", "a directory where a socket can be placed safely")
+	spanEventCmd.Flags().StringVarP(&config.EventName, "name", "e", "todo-generate-default-event-names", "set the name of the event")
+	spanEventCmd.Flags().StringVarP(&config.EventTime, "time", "t", "now", "the precise time of the event in RFC3339Nano or Unix.nano format")
+	spanEventCmd.Flags().StringVar(&config.BackgroundSockdir, "sockdir", "", "a directory where a socket can be placed safely")
 	spanEventCmd.MarkFlagRequired("sockdir")
 
 	addAttrParams(spanEventCmd)
 }
 
 func doSpanEvent(cmd *cobra.Command, args []string) {
-	timestamp := parseTime(spanEventTime, "event")
+	timestamp := parseTime(config.EventTime, "event")
 	rpcArgs := BgSpanEvent{
-		Name:       spanEventName,
+		Name:       config.EventName,
 		Timestamp:  timestamp.Format(time.RFC3339Nano),
 		Attributes: config.Attributes,
 	}


### PR DESCRIPTION
originally did this in #68 but gonna merge this real quick now so I can properly fix envvars (they're broken rn)

The diff tells the story, basically move all the global config in root.go into a Config struct.