### PR TITLE
add span background  wait

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -166,16 +166,21 @@ func printSpanData(target io.Writer, traceId, spanId, tp string) {
 }
 
 // parseCliTimeout parses the cliTimeout global string value to a time.Duration.
+// When no duration letter is provided (e.g. ms, s, m, h), seconds are assumed.
 // It logs an error and returns time.Duration(0) if the string is empty or unparseable.
 func parseCliTimeout() time.Duration {
 	if cliTimeout == "" {
 		return time.Duration(0)
 	}
 
-	if d, err := time.ParseDuration(cliTimeout); err == nil {
+	var derr error // declare early so it can be printed if both fail
+	var d time.Duration
+	if d, derr = time.ParseDuration(cliTimeout); derr == nil {
 		return d
+	} else if secs, serr := strconv.ParseInt(cliTimeout, 10, 0); serr == nil {
+		return time.Second * time.Duration(secs)
 	} else {
-		log.Printf("unable to parse --timeout %q: %s", cliTimeout, err)
+		log.Printf("unable to parse --timeout %q: %s", cliTimeout, derr)
 		return time.Duration(0)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ type Config struct {
 
 	BackgroundParentPollMs int    `json:"background_parent_poll_ms"`
 	BackgroundSockdir      string `json:"background_socket_directory"`
+	BackgroundWait         bool   `json:"background_wait"`
 
 	SpanStartTime string `json:"span_start_time"`
 	SpanEndTime   string `json:"span_end_time"`

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/spf13/viper v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0-RC1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0-RC1
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
 	go.opentelemetry.io/otel/trace v1.0.0-RC1
 	go.opentelemetry.io/proto/otlp v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,6 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0-RC1 h1:GHKxjc4EDldz8ScM
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0-RC1/go.mod h1:FliQjImlo7emZVjixV8nbDMAa4iAkcWTE9zzSEOiEPw=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0-RC1 h1:ZOQXuxKJ9evGspu3LvbZxx3KOOQvKAPBJVMOfGf1cOM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0-RC1/go.mod h1:cDwRc2Jrh5Gku1peGK8p9rRuX/Uq2OtVmLicjlw2WYU=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0-RC1 h1:SEfJImgKQ5TP2aTJwN08qhS8oFlYWr/neECGsyuxKWg=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0-RC1/go.mod h1:TAM/UYjVd1UdaifWkof3qj9cCW9oINemHfj0K6yodSo=
 go.opentelemetry.io/otel/oteltest v1.0.0-RC1 h1:G685iP3XiskCwk/z0eIabL55XUl2gk0cljhGk9sB0Yk=
 go.opentelemetry.io/otel/oteltest v1.0.0-RC1/go.mod h1:+eoIG0gdEOaPNftuy1YScLr1Gb4mL/9lpDkZ0JjMRq4=
 go.opentelemetry.io/otel/sdk v1.0.0-RC1 h1:Sy2VLOOg24bipyC29PhuMXYNJrLsxkie8hyI7kUlG9Q=


### PR DESCRIPTION
I'm working on a use case where I want this:

```sh
local otelcarrier=$(mktemp)
local sockdir=$(mktemp -d)
otel-cli span background \
	--name "$0" \
	--service "myApp" \
	--sockdir "$sockdir" \
	--tp-carrier "$otelcarrier" \
	--timeout 1800 &

source "$otelcarrier" # race condition!
```

It seems nice to source the carrier file so everything that happens in the script is a child to the background span. This has a race condition though, otel-cli might not be started up all the way and may not have written out the tp-carrier file yet. I tried to figure out a way to make otel-cli background itself but Go doesn't provide a way to do that and keep the ppid so this was the next best option.

--tp-carrier only writes the bare traceparent string to the file, I have another PR after this that changes that to be the same as the --tp-print output and respects --tp-export so it's sourceable as expected.

This adds --wait to `otel-cli span background so you can avoid the race:

```sh
local otelcarrier=$(mktemp)
local sockdir=$(mktemp -d)
otel-cli span background \
	--name "$0" \
	--service "myApp" \
	--sockdir "$sockdir" \
	--timeout 1800 &

otel-cli span background --wait --sockdir "$sockdir" --timeout 10
source "$otelcarrier" # load the new traceparent
```

Also fixes e.g. `--timeout 60` so now otel-cli assumes you want seconds for bare numbers. You can still say `--timeout 60s` and `--timeout 500ms`.

Also go mod tidy I missed when I added `status` and removed the old test mode.