### PR TITLE
make --tp-carrier file shell-compatible

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -140,20 +140,22 @@ func GetExitCode() int {
 func propagateOtelCliSpan(ctx context.Context, span trace.Span, target io.Writer) {
 	saveTraceparentToFile(ctx, config.TraceparentCarrierFile)
 
-	tpout := getTraceparent(ctx)
-	tid := span.SpanContext().TraceID().String()
-	sid := span.SpanContext().SpanID().String()
+	// --tp-print / --tp-export
+	if !config.TraceparentPrint && !config.TraceparentPrintExport {
+		return
+	}
 
-	printSpanData(target, tid, sid, tpout)
+	sc := trace.SpanContextFromContext(ctx)
+	traceId := sc.TraceID().String()
+	spanId := sc.SpanID().String()
+
+	tp := getTraceparent(ctx)
+	printSpanData(target, traceId, spanId, tp)
 }
 
 // printSpanData takes the provided strings and prints them in a consitent format,
 // depending on which command line arguments were set.
 func printSpanData(target io.Writer, traceId, spanId, tp string) {
-	// --tp-print / --tp-export
-	if !config.TraceparentPrint && !config.TraceparentPrintExport {
-		return
-	}
 
 	// --tp-export will print "export TRACEPARENT" so it's
 	// one less step to print to a file & source, or eval

--- a/cmd/otelclicarrier_test.go
+++ b/cmd/otelclicarrier_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel"
@@ -140,7 +141,10 @@ func TestWriteTraceparentToFile(t *testing.T) {
 	if len(data) == 0 {
 		t.Errorf("saveTraceparentToFile wrote %d bytes to the tempfile, expected %d", len(data), len(testTp))
 	}
-	if string(data) != testTp {
+
+	// otel is non-recording in tests so the comments in the output will be zeroed
+	// while the traceparent should come through just fine at the end of file
+	if !strings.HasSuffix(strings.TrimSpace(string(data)), testTp) {
 		t.Errorf("invalid data in traceparent file, expected '%s', got '%s'", testTp, data)
 	}
 }


### PR DESCRIPTION
This reworks mostly code that was already there for --tp-print and --tp-export so no the --tp-carrier option writes and reads the same format. This makes it so you can directly source the carrier file from shell scripts.