### PR TITLE
only print errors with --verbose and always exit 0

### DIFF
--- a/cmd/otelclicarrier.go
+++ b/cmd/otelclicarrier.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"context"
-	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -72,7 +71,7 @@ func loadTraceparent(ctx context.Context, filename string) context.Context {
 				return ctx
 			}
 		}
-		log.Fatalf("failed to find a valid traceparent carrier in either environment for file '%s' while it's required by --tp-required", filename)
+		softFail("failed to find a valid traceparent carrier in either environment for file '%s' while it's required by --tp-required", filename)
 	}
 	return ctx
 }
@@ -87,7 +86,7 @@ func loadTraceparentFromFile(ctx context.Context, filename string) context.Conte
 		// only fatal when the tp carrier file is required explicitly, otherwise
 		// just silently return the unmodified context
 		if config.TraceparentRequired {
-			log.Fatalf("could not open file '%s' for read: %s", filename, err)
+			softFail("could not open file '%s' for read: %s", filename, err)
 		} else {
 			return ctx
 		}
@@ -118,7 +117,7 @@ func loadTraceparentFromFile(ctx context.Context, filename string) context.Conte
 	tp = strings.TrimPrefix(tp, "TRACEPARENT=")
 
 	if !checkTracecarrierRe.MatchString(tp) {
-		log.Printf("file '%s' was read but does not contain a valid traceparent", filename)
+		softLog("file '%s' was read but does not contain a valid traceparent", filename)
 		return ctx
 	}
 
@@ -137,7 +136,7 @@ func saveTraceparentToFile(ctx context.Context, filename string) {
 
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
-		log.Printf("failure opening file '%s' for write: %s", filename, err)
+		softLog("failure opening file '%s' for write: %s", filename, err)
 	}
 	defer file.Close()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ type Config struct {
 	EventTime     string `json:"event_time"`
 
 	CfgFile string `json:"config_file"`
+	Verbose bool   `json:"verbose"`
 }
 
 const defaultOtlpEndpoint = "localhost:4317"
@@ -73,10 +74,13 @@ func addCommonParams(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&config.Endpoint, "endpoint", "", "dial address for the desired OTLP/gRPC endpoint")
 	// --timeout a default timeout to use in all otel-cli operations (default 1s)
 	cmd.Flags().StringVar(&config.Timeout, "timeout", "1s", "timeout for otel-cli operations, all timeouts in otel-cli use this value")
+	// --verbose tells otel-cli to actually log errors to stderr instead of failing silently
+	cmd.Flags().BoolVar(&config.Verbose, "verbose", false, "print errors on failure instead of always being silent")
 
 	var common_env_flags = map[string]string{
 		"endpoint": "OTEL_EXPORTER_OTLP_ENDPOINT",
 		"timeout":  "OTEL_EXPORTER_OTLP_TIMEOUT",
+		"verbose":  "OTEL_CLI_VERBOSE",
 	}
 
 	for config_key, env_value := range common_env_flags {

--- a/cmd/span_background.go
+++ b/cmd/span_background.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"os"
 	"os/signal"
 	"path"
@@ -72,7 +71,7 @@ func doSpanBackground(cmd *cobra.Command, args []string) {
 		defer shutdown()
 		err := client.Call("BgSpan.Wait", &struct{}{}, &struct{}{})
 		if err != nil {
-			log.Printf("error while waiting on span background: %s", err)
+			softFail("error while waiting on span background: %s", err)
 		}
 		return
 	}

--- a/cmd/span_end.go
+++ b/cmd/span_end.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -33,7 +32,7 @@ func doSpanEnd(cmd *cobra.Command, args []string) {
 	res := BgSpan{}
 	err := client.Call("BgSpan.End", rpcArgs, &res)
 	if err != nil {
-		log.Fatalf("error while calling background server rpc BgSpan.End: %s", err)
+		softFail("error while calling background server rpc BgSpan.End: %s", err)
 	}
 	shutdown()
 

--- a/cmd/span_event.go
+++ b/cmd/span_event.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"os"
 	"time"
 
@@ -52,7 +51,7 @@ func doSpanEvent(cmd *cobra.Command, args []string) {
 	defer shutdown()
 	err := client.Call("BgSpan.AddEvent", rpcArgs, &res)
 	if err != nil {
-		log.Fatalf("error while calling background server rpc BgSpan.AddEvent: %s", err)
+		softFail("error while calling background server rpc BgSpan.AddEvent: %s", err)
 	}
 
 	printSpanData(os.Stdout, res.TraceID, res.SpanID, res.Traceparent)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -51,7 +51,7 @@ func doStatus(cmd *cobra.Command, args []string) {
 				env[parts[0]] = parts[1]
 			}
 		} else {
-			log.Fatalf("BUG in otel-cli: this shouldn't happen")
+			softFail("BUG in otel-cli: this shouldn't happen")
 		}
 	}
 


### PR DESCRIPTION
adds the --verbose flag and config value

adds 2 helpers, softLog and softFail that only print if --verbose is set, and softFail always exits 0 (so otel-cli doesn't surprise people running under `set -e`)

switches the hot paths in otel-cli to use these new helpers instead of the log.Printf or log.Fatalf

/cc #56 which this takes care of