### PR TITLE
Add OTEL_EXPORTER_OTLP_ENDPOINT config to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ is specified, otel-cli will run in non-recording mode and not attempt to contact
 | --endpoint      | OTEL_EXPORTER_OTLP_ENDPOINT   | endpoint        | localhost:4317 |
 | --insecure      | OTEL_EXPORTER_OTLP_INSECURE   | insecure        | false          |
 | --timeout       | OTEL_EXPORTER_OTLP_TIMEOUT    | timeout         | 1s             |
-| --otlp-headers  | OTEL_EXPORTER_OTLP_HEADERS    | otlp-headers    | key=value      |
+| --otlp-headers  | OTEL_EXPORTER_OTLP_HEADERS    | otlp-headers    | k=v,a=b        |
 | --otlp-blocking | OTEL_EXPORTER_OTLP_BLOCKING   | otlp-blocking   | false          |
 | --service       | OTEL_CLI_SERVICE_NAME         | service         | myapp          |
 | --kind          | OTEL_CLI_TRACE_KIND           | kind            | server         |


### PR DESCRIPTION
Adds the step in the docs that I needed. This had me a bit confused.