### PR TITLE
Fix "missing 'Maintainer' field" on debian package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,7 @@ builds:
 nfpms:
   - package_name: otel-cli
     homepage: https://github.com/equinix-labs/otel-cli
+    maintainer: Amy Tobey <atobey@equinix.com>
     description: OpenTelemetry CLI Application (Server & Client)
     license: Apache 2.0
     file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Arch}}"


### PR DESCRIPTION
```
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 51362 package 'otel-cli':
 missing 'Maintainer' field
```

See https://github.com/nats-io/prometheus-nats-exporter/issues/57 for the same fix in a different package