### PR TITLE
handle OTEL_EXPORTER_OTLP_TRACES and fix unix endpoints

### DIFF
--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -51,6 +51,12 @@ func addCommonParams(cmd *cobra.Command) {
 		"timeout":  "OTEL_EXPORTER_OTLP_TIMEOUT",
 		"verbose":  "OTEL_CLI_VERBOSE",
 	}
+	if _, ok := os.LookupEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"); ok {
+		common_env_flags["endpoint"] = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	}
+	if _, ok := os.LookupEnv("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT"); ok {
+		common_env_flags["timeout"] = "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT"
+	}
 
 	for config_key, env_value := range common_env_flags {
 		viper.BindPFlag(config_key, cmd.Flags().Lookup(config_key))


### PR DESCRIPTION
These fixes are needed to make otel-cli work with BuildKit after https://github.com/moby/buildkit/pull/2572

The first commit adds support for `OTEL_EXPORTER_OTLP_TRACES_` variables for setting the trace endpoint. These are defined in https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md . These variables are defined more specifically so take priority over the generic vars if set.

The second commit fixes unix URLs.

Unix URLs should not need any special handling but the current implementation handles values without the
schema that is not allowed by the spec.

From https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md 

> The endpoint MUST be a valid URL with scheme (http or https) and host
> A scheme of https indicates a secure connection. 

If this can be removed in the future then all these exceptions can be removed as well and `WithInsecure`
is automatically detected by the endpoint value in `otlptracegrpc` package. https://github.com/open-telemetry/opentelemetry-go/blob/v1.3.0/exporters/otlp/otlptrace/internal/otlpconfig/envconfig.go#L166-L167

Currently, it fails in your custom endpoint parsing regexps that don't expect such values. Although `otlptracegrpc` correctly marks it insecure by default it is overwritten by otel-cli because it always sets TLS credentials if it can't match endpoint to a loopback name. The correct fix in here would be just to only set TLS credentials if the schema is `https` like the spec defines. Everything else is handled automatically by `otlptracegrpc`. But I didn't want to break any backward compatibility here so leave that for future development/discussion.