### PR TITLE
reference correct span parameter name

### DIFF
--- a/otelcli/span.go
+++ b/otelcli/span.go
@@ -20,7 +20,7 @@ with support for nanoseconds on both.
 
 Example:
 	otel-cli span \
-		--system "my-application" \
+		--service "my-application" \
 		--name "send data to the server" \
 		--start 2021-03-24T07:28:05.12345Z \
 		--end $(date +%s.%N) \

--- a/otelcli/span_background.go
+++ b/otelcli/span_background.go
@@ -22,7 +22,7 @@ timeout, (catchable) signals, or deliberate exit.
 
     socket_dir=$(mktemp -d)
 	otel-cli span background \
-		--system "my-long-script.sh" \
+		--service "my-long-script.sh" \
 		--name "run the script" \
 		--attrs "os.kernel=$(uname -r)" \
 		--timeout 60 \


### PR DESCRIPTION
The current behavior when using the provided example returns the following error message: `Error: unknown flag: --system`

Update the example docs to use the correct parameter name (see documentation for [span parameters](https://github.com/equinix-labs/otel-cli/blob/main/otelcli/root.go#L97-#L112)):

```go
func addSpanParams(cmd *cobra.Command) {
	// --name / -s
	cmd.Flags().StringVarP(&config.SpanName, "name", "s", defaults.SpanName, "set the name of the span")
	// --service / -n
	cmd.Flags().StringVarP(&config.ServiceName, "service", "n", defaults.ServiceName, "set the name of the application sent on the traces")
...
}
```