### PR TITLE
Upgrade jaeger and otel collector image versions

### DIFF
--- a/configs/otel-collector.yaml
+++ b/configs/otel-collector.yaml
@@ -6,10 +6,11 @@ receivers:
 
 exporters:
   logging:
-    logLevel: debug
+    loglevel: debug
   jaeger:
     endpoint: "jaeger:14250"
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:
@@ -17,10 +18,7 @@ processors:
 service:
   pipelines:
     traces:
-      receivers:
-        - otlp
-      processors:
-        - batch
-      exporters:
-        - logging
-        - jaeger
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger,logging]
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,13 +2,13 @@
 version: '2.1'
 services:
   jaeger:
-    image: jaegertracing/all-in-one:1.22.0
+    image: jaegertracing/all-in-one:1.31.0
     ports:
       - "16686:16686"
       - "14268"
       - "14250"
   otel-collector:
-    image: otel/opentelemetry-collector:0.24.0
+    image: otel/opentelemetry-collector:0.44.0
     volumes:
       - ./configs/otel-collector.yaml:/local.yaml
     command: --config /local.yaml


### PR DESCRIPTION
Thanks for this project! Really like it.

There have been lots of updates to otel collect since 0.24.0 and jaeger since 1.22.0. From my use of the docker-compose in this repo, the most notable fix is to the status codes in jaeger. They are not being parsed correctly in the current versions. Updating these versions resolved the issue for me.