### PR TITLE
Make the service/name CLI short args match the long args

### DIFF
--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -102,9 +102,9 @@ func addClientParams(cmd *cobra.Command) {
 
 func addSpanParams(cmd *cobra.Command) {
 	// --name / -s
-	cmd.Flags().StringVarP(&config.SpanName, "name", "s", defaults.SpanName, "set the name of the span")
+	cmd.Flags().StringVarP(&config.SpanName, "name", "n", defaults.SpanName, "set the name of the span")
 	// --service / -n
-	cmd.Flags().StringVarP(&config.ServiceName, "service", "n", defaults.ServiceName, "set the name of the application sent on the traces")
+	cmd.Flags().StringVarP(&config.ServiceName, "service", "s", defaults.ServiceName, "set the name of the application sent on the traces")
 	// --kind / -k
 	cmd.Flags().StringVarP(&config.Kind, "kind", "k", defaults.Kind, "set the trace kind, e.g. internal, server, client, producer, consumer")
 	var span_env_flags = map[string]string{


### PR DESCRIPTION
The current mismatch of `-n / --service` and `-s / --name` is really confusing.

I know this would probably have to be in some sort of major release, communicated beforehand, etc
But I wanted to throw this PR out to start a discussion at least :)

Another option that wouldn't involve making a breaking change could be adding an alias like `-sn` for `spanName` and `-sv` for `--service`

![image](https://user-images.githubusercontent.com/1183853/182931626-702d9ec2-195e-453c-a87b-62812c242bb8.png)
