### PR TITLE
update goreleaser config, add release procedure in README.md

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+# last updated for goreleaser v1.14.1
+
 before:
   hooks:
     - go mod tidy
@@ -44,30 +46,20 @@ nfpms:
     maintainer: Amy Tobey <atobey@equinix.com>
     description: OpenTelemetry CLI Application (Server & Client)
     license: Apache 2.0
-    file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Arch}}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
     formats:
       - apk
       - deb
       - rpm
 
 archives:
-  - name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    format: tar.gz
+  - format: tar.gz
     format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    builds_info:
+      group: root
+      owner: root
+    rlcp: true
 
 brews:
   # This means the repository must be equinix-labs/homebrew-otel-cli

--- a/README.md
+++ b/README.md
@@ -226,7 +226,22 @@ Please file issues and PRs on the GitHub project at https://github.com/equinix-l
 
 ## Releases
 
-This project is really new and still experimental, releases are TBD.
+Releases are managed by goreleaser. Currently this is limited to @tobert due to rules in
+the equinix-labs organization. For now releases are not automated, but will be by the time
+a v1.0 rolls out and the test suite is robust enough that we feel confident.
+
+Testing the release: `goreleaser release --snapshot --rm-dist`
+
+To release, a GitHub personal access token is required. The release also needs to be tagged
+in git.
+
+```shell
+git checkout main # make sure we tag on main
+git pull --rebase # get the latest HEAD
+git tag v0.1.1    # tag HEAD with the next version
+git push --tags   # push new tag up to GitHub
+goreleaser release --rm-dist
+```
 
 ## License
 


### PR DESCRIPTION
Updates the config to address deprecation warnings. Note the goreleaser version being used as of this config.

Removes some boilerplate in favor of defaults.

Adds basic release instructions to the README.md.