### PR TITLE
never allow insecure automatically for https:// URIs

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -176,6 +176,26 @@ var suites = []FixtureSuite{
 					"\"lmao\" as an bool: strconv.ParseBool: parsing \"lmao\": invalid syntax\n",
 			},
 		},
+		{
+			Name: "https:// should fail when TLS is not available",
+			Config: FixtureConfig{
+				ServerProtocol: httpProtocol,
+				CliArgs:        []string{"status", "--endpoint", "https://{{endpoint}}"},
+				TestTimeoutMs:  1000,
+			},
+			Expect: Results{
+				Config: otelcli.DefaultConfig().
+					WithEndpoint("https://{{endpoint}}"),
+				Diagnostics: otelcli.Diagnostics{
+					IsRecording:       true,
+					NumArgs:           3,
+					DetectedLocalhost: true,
+					ParsedTimeoutMs:   1000,
+					OtelError:         `traces export: Post "https://{{endpoint}}/v1/traces": http: server gave HTTP response to HTTPS client`,
+				},
+				Spans: 0,
+			},
+		},
 	},
 	// otel-cli span with no OTLP config should do and print nothing
 	{

--- a/otelcli/plumbing.go
+++ b/otelcli/plumbing.go
@@ -125,7 +125,7 @@ func grpcOptions() []otlpgrpc.Option {
 	// have any encryption available, or setting it up raises the bar of entry too high.
 	// The compromise is to automatically flip this flag to true when endpoint contains an
 	// an obvious "localhost", "127.0.0.x", or "::1" address.
-	if config.Insecure || isLoopbackAddr(config.Endpoint) {
+	if config.Insecure || (isLoopbackAddr(config.Endpoint) && !strings.HasPrefix(config.Endpoint, "https")) {
 		grpcOpts = append(grpcOpts, otlpgrpc.WithInsecure())
 	} else if !isInsecureSchema(config.Endpoint) {
 		var tlsConfig *tls.Config
@@ -190,7 +190,7 @@ func httpOptions() []otlphttp.Option {
 	// raises the bar of entry too high.  The compromise is to automatically flip
 	// this flag to true when endpoint contains an an obvious "localhost",
 	// "127.0.0.x", or "::1" address.
-	if config.Insecure || isLoopbackAddr(config.Endpoint) {
+	if config.Insecure || (isLoopbackAddr(config.Endpoint) && !strings.HasPrefix(config.Endpoint, "https")) {
 		httpOpts = append(httpOpts, otlphttp.WithInsecure())
 	} else if !isInsecureSchema(config.Endpoint) {
 		var tlsConfig *tls.Config


### PR DESCRIPTION
While working on another branch to add TLS testing, I added the included test to validate that https://endpoint would FAIL on a cleartext server. I was surprised when it didn't fail and immediately wrote this PR. There may be more work needed but this at least takes care of the most egregious case.

I don't think there's any impact to non-localhost clients or servers, so impact is pretty small.