### PR TITLE
fix config for the otel error handler

### DIFF
--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -19,6 +19,11 @@ var rootCmd = &cobra.Command{
 			// will need to specify --fail --verbose flags to see these errors
 			softFail("Error while loading environment variables: %s", err)
 		}
+
+		// plug a copy of the completed config into diagnostics
+		// so the otel error handler can check --fail/--verbose config
+		// this should go away after rewriting the otel exporter
+		diagnostics.config = config
 	},
 }
 


### PR DESCRIPTION
Not super happy with the diagnostics change but gonna leave it for now since it is in the right direction of getting rid of the config package global. Also the need for this goes away if/when I write a custom exporter instead of using the otel collector backend.