### PR TITLE
allow setting status code and description at the end of background spans #197

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -586,6 +586,17 @@ var suites = []FixtureSuite{
 				SpanCount:  1,
 				EventCount: 1,
 			},
+			// this validates options sent to otel-cli span end
+			CheckFuncs: []CheckFunc{
+				func(t *testing.T, f Fixture, r Results) {
+					if r.Span.StatusCode != 2 {
+						t.Errorf("expected 2 for span status code, but got %d", r.Span.StatusCode)
+					}
+					if r.Span.StatusDescription != "I can't do that Dave." {
+						t.Errorf("got wrong string for status description: %q", r.Span.StatusDescription)
+					}
+				},
+			},
 		},
 		{
 			Name: "otel-cli span event",
@@ -597,7 +608,13 @@ var suites = []FixtureSuite{
 		{
 			Name: "otel-cli span end",
 			Config: FixtureConfig{
-				CliArgs: []string{"span", "end", "--sockdir", "."},
+				CliArgs: []string{
+					"span", "end",
+					"--sockdir", ".",
+					// these are validated by checkfuncs defined above ^^
+					"--status-code", "error",
+					"--status-description", "I can't do that Dave.",
+				},
 			},
 			Expect: Results{Config: otelcli.DefaultConfig()},
 		},

--- a/otelcli/protobuf_span.go
+++ b/otelcli/protobuf_span.go
@@ -86,15 +86,21 @@ func NewProtobufSpanWithConfig(c Config) tracepb.Span {
 		span.SpanId = emptySpanId
 	}
 
-	// Only set status description when an error status.
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/480a19d702470563d32a870932be5ddae798079c/specification/trace/api.md#set-status
+	SetSpanStatus(&span, c)
+
+	return span
+}
+
+// SetSpanStatus checks for status code error in the config and sets the
+// span's 2 values as appropriate.
+// Only set status description when an error status.
+// https://github.com/open-telemetry/opentelemetry-specification/blob/480a19d702470563d32a870932be5ddae798079c/specification/trace/api.md#set-status
+func SetSpanStatus(span *tracepb.Span, c Config) {
 	statusCode := SpanStatusStringToInt(c.StatusCode)
-	if statusCode == tracepb.Status_STATUS_CODE_ERROR {
+	if statusCode != tracepb.Status_STATUS_CODE_UNSET {
 		span.Status.Code = statusCode
 		span.Status.Message = c.StatusDescription
 	}
-
-	return span
 }
 
 // generateTraceId generates a random 16 byte trace id

--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -99,6 +99,13 @@ func addSpanParams(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&config.ServiceName, "service", "s", defaults.ServiceName, "set the name of the application sent on the traces")
 	// --kind / -k
 	cmd.Flags().StringVarP(&config.Kind, "kind", "k", defaults.Kind, "set the trace kind, e.g. internal, server, client, producer, consumer")
+
+	addSpanStatusParams(cmd)
+}
+
+func addSpanStatusParams(cmd *cobra.Command) {
+	defaults := DefaultConfig()
+
 	// --status-code / -sc
 	cmd.Flags().StringVar(&config.StatusCode, "status-code", defaults.StatusCode, "set the span status code, e.g. unset|ok|error")
 	// --status-description / -sd

--- a/otelcli/span_background.go
+++ b/otelcli/span_background.go
@@ -87,7 +87,7 @@ func doSpanBackground(cmd *cobra.Command, args []string) {
 	// propagation before the server starts, instead of after
 	propagateTraceparent(span, os.Stdout)
 
-	bgs := createBgServer(spanBgSockfile(), span)
+	bgs := createBgServer(spanBgSockfile(), &span)
 
 	// set up signal handlers to cleanly exit on SIGINT/SIGTERM etc
 	signals := make(chan os.Signal)

--- a/otelcli/span_end.go
+++ b/otelcli/span_end.go
@@ -27,12 +27,20 @@ func init() {
 	//spanEndCmd.Flags().StringVar(&config.Timeout, "timeout", defaults.Timeout, "timeout for otel-cli operations, all timeouts in otel-cli use this value")
 	spanEndCmd.Flags().StringVar(&config.BackgroundSockdir, "sockdir", defaults.BackgroundSockdir, "a directory where a socket can be placed safely")
 	spanEndCmd.MarkFlagRequired("sockdir")
+
+	spanEndCmd.Flags().StringVar(&config.SpanEndTime, "end", defaults.SpanEndTime, "an Unix epoch or RFC3339 timestamp for the end of the span")
+
+	addSpanStatusParams(spanEndCmd)
 }
 
 func doSpanEnd(cmd *cobra.Command, args []string) {
 	client, shutdown := createBgClient()
 
-	rpcArgs := BgEnd{}
+	rpcArgs := BgEnd{
+		StatusCode: config.StatusCode,
+		StatusDesc: config.StatusDescription,
+	}
+
 	res := BgSpan{}
 	err := client.Call("BgSpan.End", rpcArgs, &res)
 	if err != nil {

--- a/otlpserver/clievent.go
+++ b/otlpserver/clievent.go
@@ -25,6 +25,8 @@ type CliEvent struct {
 	ElapsedMs         int64             `json:"elapsed_ms"`
 	Attributes        map[string]string `json:"attributes"`
 	ServiceAttributes map[string]string `json:"service_attributes"`
+	StatusCode        int32
+	StatusDescription string
 	// for a span this is the start nanos, for an event it's just the timestamp
 	// mostly here for sorting CliEventList but could be any uint64
 	Nanos uint64 `json:"nanos"`
@@ -62,6 +64,8 @@ func (ce CliEvent) ToStringMap() map[string]string {
 		"end":                etime,
 		"attributes":         mapToKVString(ce.Attributes),
 		"service_attributes": mapToKVString(ce.ServiceAttributes),
+		"status_code":        strconv.FormatInt(int64(ce.StatusCode), 10),
+		"status_description": ce.StatusDescription,
 		"is_populated":       strconv.FormatBool(ce.IsPopulated),
 		"server_meta":        mapToKVString(ce.ServerMeta),
 	}
@@ -88,6 +92,8 @@ func NewCliEventFromSpan(span *v1.Span, scopeSpans *v1.ScopeSpans, rss *v1.Resou
 		Attributes:        make(map[string]string),
 		ServiceAttributes: make(map[string]string),
 		Nanos:             span.GetStartTimeUnixNano(),
+		StatusCode:        int32(span.GetStatus().Code),
+		StatusDescription: span.GetStatus().Message,
 		IsPopulated:       true,
 		ServerMeta:        make(map[string]string),
 	}


### PR DESCRIPTION
Per #197, this adds `otel-cli span end --status-code error --status-description ono`. The status code and description are sent through JSON-RPC to the backend which updates the span before sending it upstream.