### PR TITLE
make exec arg handling precise (#191)

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -614,7 +614,8 @@ var suites = []FixtureSuite{
 		{
 			Name: "otel-cli span exec echo",
 			Config: FixtureConfig{
-				CliArgs: []string{"exec", "--service", "main_test.go", "--name", "test-span-123", "--kind", "server", "echo hello world"},
+				// intentionally calling a command with no args bc it's a special case in exec.go
+				CliArgs: []string{"exec", "--service", "main_test.go", "--name", "test-span-123", "--kind", "server", "echo"},
 				Env: map[string]string{
 					"OTEL_EXPORTER_OTLP_ENDPOINT": "{{endpoint}}",
 					"TRACEPARENT":                 "00-edededededededededededededed9000-edededededededed-01",
@@ -626,7 +627,7 @@ var suites = []FixtureSuite{
 					"span_id":  "*",
 					"trace_id": "edededededededededededededed9000",
 				},
-				CliOutput: "hello world\n",
+				CliOutput: "\n",
 				SpanCount: 1,
 			},
 		},
@@ -638,7 +639,7 @@ var suites = []FixtureSuite{
 			Config: FixtureConfig{
 				CliArgs: []string{
 					"exec", "--name", "outer", "--endpoint", "{{endpoint}}", "--fail", "--verbose", "--",
-					"./otel-cli", "exec", "--name", "inner", "--endpoint", "{{endpoint}}", "--tp-required", "--fail", "--verbose", "echo hello world"},
+					"./otel-cli", "exec", "--name", "inner", "--endpoint", "{{endpoint}}", "--tp-required", "--fail", "--verbose", "echo", "hello world"},
 			},
 			Expect: Results{
 				Config: otelcli.DefaultConfig(),


### PR DESCRIPTION
Required fixing the tests which quoted "echo hello world" as one argv, which never should have worked, but did because of sh -c.

This changes behavior in otel-cli to be more picky about how args are passed in. It might break some folks who are expecting sh -c behavior?

Gonna post the diffs/PR and have a discussion in #191.