### PR TITLE
switch otel-cli to use a custom otlp client

### DIFF
--- a/otlpclient/client.go
+++ b/otlpclient/client.go
@@ -1,0 +1,8 @@
+package otlpclient
+
+type Client struct {
+}
+
+func NewClient() Client {
+	return Client{}
+}

--- a/otlpclient/client_test.go
+++ b/otlpclient/client_test.go
@@ -1,0 +1,1 @@
+package otlpclient

--- a/otlpclient/grpc.go
+++ b/otlpclient/grpc.go
@@ -1,0 +1,1 @@
+package otlpclient

--- a/otlpclient/grpc_test.go
+++ b/otlpclient/grpc_test.go
@@ -1,0 +1,1 @@
+package otlpclient

--- a/otlpclient/http.go
+++ b/otlpclient/http.go
@@ -1,0 +1,1 @@
+package otlpclient

--- a/otlpclient/http_test.go
+++ b/otlpclient/http_test.go
@@ -1,0 +1,1 @@
+package otlpclient


### PR DESCRIPTION
When this PR is ready, it will offer new grpc and http/protobuf OTLP clients in a package, that will be integrated into otel-cli to replace the OTel collector's exporters that are in use now.