### PR TITLE
add --force-trace-id and --force-span-id options (#173)

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -846,4 +846,32 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
+	// --trace-id and --span-id allow setting/forcing custom trace & span ids
+	{
+		{
+			Name: "forced trace & span ids",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"status",
+					"--endpoint", "{{endpoint}}",
+					"--force-trace-id", "00112233445566778899aabbccddeeff",
+					"--force-span-id", "beefcafefacedead",
+				},
+			},
+			Expect: Results{
+				Config: otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
+				SpanData: map[string]string{
+					"trace_id": "00112233445566778899aabbccddeeff",
+					"span_id":  "beefcafefacedead",
+				},
+				SpanCount: 1,
+				Diagnostics: otelcli.Diagnostics{
+					NumArgs:           7,
+					IsRecording:       true,
+					DetectedLocalhost: true,
+					ParsedTimeoutMs:   1000,
+				},
+			},
+		},
+	},
 }

--- a/otelcli/config.go
+++ b/otelcli/config.go
@@ -33,6 +33,8 @@ func DefaultConfig() Config {
 		ServiceName:                  "otel-cli",
 		SpanName:                     "todo-generate-default-span-names",
 		Kind:                         "client",
+		ForceTraceId:                 "",
+		ForceSpanId:                  "",
 		Attributes:                   map[string]string{},
 		TraceparentCarrierFile:       "",
 		TraceparentIgnoreEnv:         false,
@@ -78,6 +80,8 @@ type Config struct {
 	Attributes        map[string]string `json:"span_attributes" env:"OTEL_CLI_ATTRIBUTES"`
 	StatusCode        string            `json:"span_status_code" env:"OTEL_CLI_STATUS_CODE"`
 	StatusDescription string            `json:"span_status_description" env:"OTEL_CLI_STATUS_DESCRIPTION"`
+	ForceSpanId       string            `json:"span_id" env:"OTEL_CLI_FORCE_SPAN_ID"`
+	ForceTraceId      string            `json:"trace_id" env:"OTEL_CLI_FORCE_TRACE_ID"`
 
 	TraceparentCarrierFile string `json:"traceparent_carrier_file" env:"OTEL_CLI_CARRIER_FILE"`
 	TraceparentIgnoreEnv   bool   `json:"traceparent_ignore_env" env:"OTEL_CLI_IGNORE_ENV"`

--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -109,6 +109,10 @@ func addSpanParams(cmd *cobra.Command) {
 	// --kind / -k
 	cmd.Flags().StringVarP(&config.Kind, "kind", "k", defaults.Kind, "set the trace kind, e.g. internal, server, client, producer, consumer")
 
+	// expert options: --force-trace-id, --force-span-id allow setting custom trace & span ids
+	cmd.Flags().StringVar(&config.ForceTraceId, "force-trace-id", defaults.ForceTraceId, "expert: force the trace id to be the one provided in hex")
+	cmd.Flags().StringVar(&config.ForceSpanId, "force-span-id", defaults.ForceSpanId, "expert: force the span id to be the one provided in hex")
+
 	addSpanStatusParams(cmd)
 }
 

--- a/otelcli/status.go
+++ b/otelcli/status.go
@@ -36,6 +36,7 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 	addCommonParams(statusCmd)
 	addClientParams(statusCmd)
+	addSpanParams(statusCmd)
 }
 
 func doStatus(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Adds `--force-trace-id` and `--force-span-id` options to all of the span-producing commands, `exec`, `span`, `background`, and `status`.

To make this simple to test, `otel-cli status` now accepts span options.