### PR TITLE
move error tracking to context values, add multiple canaries to otel-cli status

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -96,8 +96,9 @@ var suites = []FixtureSuite{
 			Expect: Results{
 				Config: otlpclient.DefaultConfig(),
 				Diagnostics: otlpclient.Diagnostics{
-					IsRecording: false,
-					NumArgs:     1,
+					IsRecording:     false,
+					NumArgs:         1,
+					ParsedTimeoutMs: 1000,
 				},
 			},
 		},

--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -98,9 +98,14 @@ func doExec(cmd *cobra.Command, args []string) {
 	}
 	span.EndTimeUnixNano = uint64(time.Now().UnixNano())
 
-	err := otlpclient.SendSpan(ctx, client, config, span)
+	ctx, err := otlpclient.SendSpan(ctx, client, config, span)
 	if err != nil {
 		config.SoftFail("unable to send span: %s", err)
+	}
+
+	_, err = client.Stop(ctx)
+	if err != nil {
+		config.SoftFail("client.Stop() failed: %s", err)
 	}
 
 	// set the global exit code so main() can grab it and os.Exit() properly

--- a/otelcli/span.go
+++ b/otelcli/span.go
@@ -49,7 +49,9 @@ func doSpan(cmd *cobra.Command, args []string) {
 	config := getConfig(ctx)
 	ctx, client := otlpclient.StartClient(ctx, config)
 	span := otlpclient.NewProtobufSpanWithConfig(config)
-	err := otlpclient.SendSpan(ctx, client, config, span)
+	ctx, err := otlpclient.SendSpan(ctx, client, config, span)
+	config.SoftFailIfErr(err)
+	_, err = client.Stop(ctx)
 	config.SoftFailIfErr(err)
 	otlpclient.PropagateTraceparent(config, span, os.Stdout)
 }

--- a/otelcli/span_background.go
+++ b/otelcli/span_background.go
@@ -133,7 +133,7 @@ func doSpanBackground(cmd *cobra.Command, args []string) {
 	bgs.Run()
 
 	span.EndTimeUnixNano = uint64(time.Now().UnixNano())
-	err := otlpclient.SendSpan(ctx, client, config, span)
+	_, err := otlpclient.SendSpan(ctx, client, config, span)
 	if err != nil {
 		config.SoftFail("Sending span failed: %s", err)
 	}

--- a/otelcli/status.go
+++ b/otelcli/status.go
@@ -117,6 +117,8 @@ func doStatus(cmd *cobra.Command, args []string) {
 		config.SoftFail("client.Stop() failed: %s", err)
 	}
 
+	// otlpclient saves all errors to a key in context so they can be used
+	// to validate assumptions here & in tests
 	errorList := otlpclient.GetErrorList(ctx)
 
 	// TODO: does it make sense to turn SpanData into a list of spans?

--- a/otelcli/status.go
+++ b/otelcli/status.go
@@ -95,6 +95,7 @@ func doStatus(cmd *cobra.Command, args []string) {
 
 		// when doing --keepalive, child each new span to the previous one
 		if lastSpan != nil {
+			span.TraceId = lastSpan.TraceId
 			span.ParentSpanId = lastSpan.SpanId
 		}
 		lastSpan = span

--- a/otelcli/status.go
+++ b/otelcli/status.go
@@ -91,7 +91,7 @@ func doStatus(cmd *cobra.Command, args []string) {
 		}
 		span.Kind = tracepb.Span_SPAN_KIND_INTERNAL
 
-		// when doing --keepalive, child each new span to the previous one
+		// when doing multiple canaries, child each new span to the previous one
 		if lastSpan != nil {
 			span.TraceId = lastSpan.TraceId
 			span.ParentSpanId = lastSpan.SpanId

--- a/otelcli/status.go
+++ b/otelcli/status.go
@@ -86,7 +86,7 @@ func doStatus(cmd *cobra.Command, args []string) {
 		config.SoftFail("client.Stop() failed: %s", err)
 	}
 
-	_, errorList := otlpclient.GetErrorList(ctx)
+	errorList := otlpclient.GetErrorList(ctx)
 
 	outData := StatusOutput{
 		Config: config,

--- a/otlpclient/config.go
+++ b/otlpclient/config.go
@@ -52,7 +52,7 @@ func DefaultConfig() Config {
 		BackgroundSockdir:            "",
 		BackgroundWait:               false,
 		BackgroundSkipParentPidCheck: false,
-		StatusCanaryCount:            0,
+		StatusCanaryCount:            1,
 		StatusCanaryInterval:         "",
 		SpanStartTime:                "now",
 		SpanEndTime:                  "now",

--- a/otlpclient/config.go
+++ b/otlpclient/config.go
@@ -52,7 +52,8 @@ func DefaultConfig() Config {
 		BackgroundSockdir:            "",
 		BackgroundWait:               false,
 		BackgroundSkipParentPidCheck: false,
-		StatusKeepaliveMs:            0,
+		StatusCanaryCount:            0,
+		StatusCanaryIntervalMs:       0,
 		SpanStartTime:                "now",
 		SpanEndTime:                  "now",
 		EventName:                    "todo-generate-default-event-names",
@@ -103,7 +104,8 @@ type Config struct {
 	BackgroundWait               bool   `json:"background_wait" env:""`
 	BackgroundSkipParentPidCheck bool   `json:"background_skip_parent_pid_check"`
 
-	StatusKeepaliveMs int `json:"status_keepalive_ms"`
+	StatusCanaryCount      int `json:"status_canary_count"`
+	StatusCanaryIntervalMs int `json:"status_canary_interval_ms"`
 
 	SpanStartTime string `json:"span_start_time" env:""`
 	SpanEndTime   string `json:"span_end_time" env:""`
@@ -591,9 +593,15 @@ func (c Config) WithBackgroundSkipParentPidCheck(with bool) Config {
 	return c
 }
 
-// WithStatusKeepliaveMs returns the config with StatusKeepaliveMs set to the provided value.
-func (c Config) WithStatusKeepaliveMs(with int) Config {
-	c.StatusKeepaliveMs = with
+// WithStatusCanaryCount returns the config with StatusCanaryCount set to the provided value.
+func (c Config) WithStatusCanaryCount(with int) Config {
+	c.StatusCanaryCount = with
+	return c
+}
+
+// WithStatusCanaryIntervalMs returns the config with StatusCanaryIntervalMs set to the provided value.
+func (c Config) WithStatusCanaryIntervalMs(with int) Config {
+	c.StatusCanaryIntervalMs = with
 	return c
 }
 

--- a/otlpclient/config.go
+++ b/otlpclient/config.go
@@ -249,6 +249,7 @@ func (c Config) IsRecording() bool {
 // ParseCliTimeout parses the --timeout string value to a time.Duration.
 func (c Config) ParseCliTimeout() time.Duration {
 	out, err := parseDuration(c.Timeout)
+	Diag.ParsedTimeoutMs = out.Milliseconds()
 	c.SoftFailIfErr(err)
 	return out
 }
@@ -275,7 +276,6 @@ func parseDuration(d string) (time.Duration, error) {
 		return time.Duration(0), fmt.Errorf("unable to parse duration string %q: %s", d, err)
 	}
 
-	Diag.ParsedTimeoutMs = out.Milliseconds()
 	return out, nil
 }
 

--- a/otlpclient/config.go
+++ b/otlpclient/config.go
@@ -52,6 +52,7 @@ func DefaultConfig() Config {
 		BackgroundSockdir:            "",
 		BackgroundWait:               false,
 		BackgroundSkipParentPidCheck: false,
+		StatusKeepaliveMs:            0,
 		SpanStartTime:                "now",
 		SpanEndTime:                  "now",
 		EventName:                    "todo-generate-default-event-names",
@@ -101,6 +102,8 @@ type Config struct {
 	BackgroundSockdir            string `json:"background_socket_directory" env:""`
 	BackgroundWait               bool   `json:"background_wait" env:""`
 	BackgroundSkipParentPidCheck bool   `json:"background_skip_parent_pid_check"`
+
+	StatusKeepaliveMs int `json:"status_keepalive_ms"`
 
 	SpanStartTime string `json:"span_start_time" env:""`
 	SpanEndTime   string `json:"span_end_time" env:""`
@@ -585,6 +588,12 @@ func (c Config) WithBackgroundWait(with bool) Config {
 // WithBackgroundSkipParentPidCheck returns the config with BackgroundSkipParentPidCheck set to the provided value.
 func (c Config) WithBackgroundSkipParentPidCheck(with bool) Config {
 	c.BackgroundSkipParentPidCheck = with
+	return c
+}
+
+// WithStatusKeepliaveMs returns the config with StatusKeepaliveMs set to the provided value.
+func (c Config) WithStatusKeepaliveMs(with int) Config {
+	c.StatusKeepaliveMs = with
 	return c
 }
 

--- a/otlpclient/config_test.go
+++ b/otlpclient/config_test.go
@@ -311,8 +311,8 @@ func TestWithStatusCanaryCount(t *testing.T) {
 		t.Fail()
 	}
 }
-func TestWithStatusCanaryIntervalMs(t *testing.T) {
-	if DefaultConfig().WithStatusCanaryIntervalMs(1337).StatusCanaryIntervalMs != 1337 {
+func TestWithStatusCanaryInterval(t *testing.T) {
+	if DefaultConfig().WithStatusCanaryInterval("1337ms").StatusCanaryInterval != "1337ms" {
 		t.Fail()
 	}
 }

--- a/otlpclient/config_test.go
+++ b/otlpclient/config_test.go
@@ -306,6 +306,16 @@ func TestWithBackgroundWait(t *testing.T) {
 		t.Fail()
 	}
 }
+func TestWithStatusCanaryCount(t *testing.T) {
+	if DefaultConfig().WithStatusCanaryCount(1337).StatusCanaryCount != 1337 {
+		t.Fail()
+	}
+}
+func TestWithStatusCanaryIntervalMs(t *testing.T) {
+	if DefaultConfig().WithStatusCanaryIntervalMs(1337).StatusCanaryIntervalMs != 1337 {
+		t.Fail()
+	}
+}
 func TestWithSpanStartTime(t *testing.T) {
 	if DefaultConfig().WithSpanStartTime("foobar").SpanStartTime != "foobar" {
 		t.Fail()

--- a/otlpclient/otlp_client.go
+++ b/otlpclient/otlp_client.go
@@ -302,8 +302,8 @@ type otlpClientCtxKey string
 
 // TimestampedError is a timestamp + error string, to be stored in an ErrorList
 type TimestampedError struct {
-	Timestamp time.Time
-	Error     string
+	Timestamp time.Time `json:"timestamp"`
+	Error     string    `json:"error"`
 }
 
 // ErrorList is a list of TimestampedError

--- a/otlpclient/otlp_client.go
+++ b/otlpclient/otlp_client.go
@@ -336,6 +336,10 @@ func GetErrorList(ctx context.Context) ErrorList {
 // SaveError writes the provided error to the ErrorList in ctx, returning an
 // updated ctx.
 func SaveError(ctx context.Context, err error) (context.Context, error) {
+	if err == nil {
+		return ctx, nil
+	}
+
 	Diag.SetError(err) // legacy, will go away when Diag is removed
 
 	te := TimestampedError{

--- a/otlpclient/otlp_client.go
+++ b/otlpclient/otlp_client.go
@@ -97,11 +97,6 @@ func SendSpan(ctx context.Context, client OTLPClient, config Config, span *trace
 		return SaveError(ctx, err)
 	}
 
-	_, err = client.Stop(ctx)
-	if err != nil {
-		return SaveError(ctx, err)
-	}
-
 	return ctx, nil
 }
 

--- a/otlpclient/otlp_client.go
+++ b/otlpclient/otlp_client.go
@@ -370,6 +370,9 @@ func retry(ctx context.Context, config Config, timeout time.Duration, fun retryF
 	sleep := time.Duration(0)
 	for {
 		if ctx, keepGoing, wait, err := fun(ctx); err != nil {
+			if err != nil {
+				ctx, _ = SaveError(ctx, err)
+			}
 			config.SoftLog("error on retry %d: %s", Diag.Retries, err)
 
 			if keepGoing {

--- a/otlpclient/otlp_client_grpc.go
+++ b/otlpclient/otlp_client_grpc.go
@@ -80,8 +80,6 @@ func (gc *GrpcClient) UploadTraces(ctx context.Context, rsps []*tracepb.Resource
 	grpcOpts := []grpc.CallOption{grpc.HeaderCallOption{HeaderAddr: &md}}
 
 	req := coltracepb.ExportTraceServiceRequest{ResourceSpans: rsps}
-	ctx, cancel := deadlineCtx(ctx, gc.config, gc.config.StartupTime)
-	defer cancel()
 
 	timeout := gc.config.ParseCliTimeout()
 	return retry(ctx, gc.config, timeout, func(innerCtx context.Context) (context.Context, bool, time.Duration, error) {
@@ -92,8 +90,7 @@ func (gc *GrpcClient) UploadTraces(ctx context.Context, rsps []*tracepb.Resource
 
 // Stop closes the connection to the gRPC server.
 func (gc *GrpcClient) Stop(ctx context.Context) (context.Context, error) {
-	gc.conn.Close() // ignoring the error
-	return ctx, nil
+	return ctx, gc.conn.Close()
 }
 
 func processGrpcStatus(ctx context.Context, etsr *coltracepb.ExportTraceServiceResponse, err error) (context.Context, bool, time.Duration, error) {

--- a/otlpclient/otlp_client_grpc.go
+++ b/otlpclient/otlp_client_grpc.go
@@ -92,7 +92,8 @@ func (gc *GrpcClient) UploadTraces(ctx context.Context, rsps []*tracepb.Resource
 
 // Stop closes the connection to the gRPC server.
 func (gc *GrpcClient) Stop(ctx context.Context) (context.Context, error) {
-	return ctx, gc.conn.Close()
+	gc.conn.Close() // ignoring the error
+	return ctx, nil
 }
 
 func processGrpcStatus(ctx context.Context, etsr *coltracepb.ExportTraceServiceResponse, err error) (context.Context, bool, time.Duration, error) {

--- a/otlpclient/otlp_client_grpc_test.go
+++ b/otlpclient/otlp_client_grpc_test.go
@@ -1,6 +1,7 @@
 package otlpclient
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -56,7 +57,8 @@ func TestProcessGrpcStatus(t *testing.T) {
 			wait:      time.Second,
 		},
 	} {
-		kg, wait, err := processGrpcStatus(tc.etsr, tc.err)
+		ctx := context.Background()
+		_, kg, wait, err := processGrpcStatus(ctx, tc.etsr, tc.err)
 
 		if kg != tc.keepgoing {
 			t.Errorf("keepgoing value returned %t but expected %t in test %d", kg, tc.keepgoing, i)

--- a/otlpclient/otlp_client_http.go
+++ b/otlpclient/otlp_client_http.go
@@ -33,7 +33,7 @@ func NewHttpClient(config Config) *HttpClient {
 
 // Start sets up the client configuration.
 // TODO: see if there's a way to background start http2 connections?
-func (hc *HttpClient) Start(ctx context.Context) error {
+func (hc *HttpClient) Start(ctx context.Context) (context.Context, error) {
 	tlsConf := tlsConfig(hc.config)
 	hc.timeout = hc.config.ParseCliTimeout()
 
@@ -54,22 +54,22 @@ func (hc *HttpClient) Start(ctx context.Context) error {
 	} else {
 		hc.config.SoftFail("BUG in otel-cli: an invalid configuration made it too far. Please report to https://github.com/equinix-labs/otel-cli/issues.")
 	}
-	return nil
+	return ctx, nil
 }
 
 // UploadTraces sends the protobuf spans up to the HTTP server.
-func (hc *HttpClient) UploadTraces(ctx context.Context, rsps []*tracepb.ResourceSpans) error {
+func (hc *HttpClient) UploadTraces(ctx context.Context, rsps []*tracepb.ResourceSpans) (context.Context, error) {
 	msg := coltracepb.ExportTraceServiceRequest{ResourceSpans: rsps}
 	protoMsg, err := proto.Marshal(&msg)
 	if err != nil {
-		return fmt.Errorf("failed to marshal trace service request: %w", err)
+		return ctx, fmt.Errorf("failed to marshal trace service request: %w", err)
 	}
 	body := bytes.NewBuffer(protoMsg)
 
 	endpointURL, _ := ParseEndpoint(hc.config)
 	req, err := http.NewRequest("POST", endpointURL.String(), body)
 	if err != nil {
-		return fmt.Errorf("failed to create HTTP POST request: %w", err)
+		return ctx, fmt.Errorf("failed to create HTTP POST request: %w", err)
 	}
 
 	for k, v := range hc.config.Headers {
@@ -77,27 +77,27 @@ func (hc *HttpClient) UploadTraces(ctx context.Context, rsps []*tracepb.Resource
 	}
 	req.Header.Set("Content-Type", "application/x-protobuf")
 
-	return retry(hc.config, hc.timeout, func() (bool, time.Duration, error) {
+	return retry(ctx, hc.config, hc.timeout, func(context.Context) (context.Context, bool, time.Duration, error) {
 		var body []byte
 		resp, err := hc.client.Do(req)
 		if uerr, ok := err.(*url.Error); ok {
 			// e.g. http on https, un-retriable error, quit now
-			return false, 0, uerr
+			return ctx, false, 0, uerr
 		} else {
 			body, err = io.ReadAll(resp.Body)
 			if err != nil {
-				return true, 0, fmt.Errorf("io.Readall of response body failed: %w", err)
+				return ctx, true, 0, fmt.Errorf("io.Readall of response body failed: %w", err)
 			}
 			resp.Body.Close()
 
-			return processHTTPStatus(resp, body)
+			return processHTTPStatus(ctx, resp, body)
 		}
 	})
 }
 
 // processHTTPStatus takes the http.Response and body, returning the same bool, error
 // as retryFunc. Mostly it's broken out so it can be unit tested.
-func processHTTPStatus(resp *http.Response, body []byte) (bool, time.Duration, error) {
+func processHTTPStatus(ctx context.Context, resp *http.Response, body []byte) (context.Context, bool, time.Duration, error) {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		// success & partial success
 		// spec says server MUST send 200 OK, we'll be generous and accept any 200
@@ -105,39 +105,39 @@ func processHTTPStatus(resp *http.Response, body []byte) (bool, time.Duration, e
 		err := proto.Unmarshal(body, &etsr)
 		if err != nil {
 			// if the server's sending garbage, no point in retrying
-			return false, 0, fmt.Errorf("unmarshal of server response failed: %w", err)
+			return ctx, false, 0, fmt.Errorf("unmarshal of server response failed: %w", err)
 		}
 
 		if partial := etsr.GetPartialSuccess(); partial != nil {
 			// spec says to stop retrying and drop rejected spans
-			return false, 0, fmt.Errorf("partial success. %d spans were rejected", partial.GetRejectedSpans())
+			return ctx, false, 0, fmt.Errorf("partial success. %d spans were rejected", partial.GetRejectedSpans())
 
 		} else {
 			// full success!
-			return false, 0, nil
+			return ctx, false, 0, nil
 		}
 	} else if resp.StatusCode == 429 || resp.StatusCode == 502 || resp.StatusCode == 503 || resp.StatusCode == 504 {
 		// 429, 502, 503, and 504 must be retried according to spec
-		return true, 0, fmt.Errorf("server responded with retriable code %d", resp.StatusCode)
+		return ctx, true, 0, fmt.Errorf("server responded with retriable code %d", resp.StatusCode)
 	} else if resp.StatusCode >= 300 && resp.StatusCode < 400 {
 		// spec doesn't say anything 300's, ignore body and assume they're errors and unretriable
-		return false, 0, fmt.Errorf("server returned unsupported code %d", resp.StatusCode)
+		return ctx, false, 0, fmt.Errorf("server returned unsupported code %d", resp.StatusCode)
 	} else if resp.StatusCode >= 400 {
 		// https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures-1
 		st := status.Status{}
 		err := proto.Unmarshal(body, &st)
 		if err != nil {
-			return false, 0, fmt.Errorf("unmarshal of server status failed: %w", err)
+			return ctx, false, 0, fmt.Errorf("unmarshal of server status failed: %w", err)
 		} else {
-			return false, 0, fmt.Errorf("server returned unretriable code %d with status: %s", resp.StatusCode, st.GetMessage())
+			return ctx, false, 0, fmt.Errorf("server returned unretriable code %d with status: %s", resp.StatusCode, st.GetMessage())
 		}
 	}
 
 	// should never happen
-	return false, 0, fmt.Errorf("BUG: fell through error checking with status code %d", resp.StatusCode)
+	return ctx, false, 0, fmt.Errorf("BUG: fell through error checking with status code %d", resp.StatusCode)
 }
 
 // Stop does nothing for HTTP, for now. It exists to fulfill the interface.
-func (hc *HttpClient) Stop(ctx context.Context) error {
-	return nil
+func (hc *HttpClient) Stop(ctx context.Context) (context.Context, error) {
+	return ctx, nil
 }

--- a/otlpclient/otlp_client_http_test.go
+++ b/otlpclient/otlp_client_http_test.go
@@ -1,6 +1,7 @@
 package otlpclient
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -97,7 +98,8 @@ func TestProcessHTTPStatus(t *testing.T) {
 			err:       fmt.Errorf("BUG: fell through error checking with status code 0"),
 		},
 	} {
-		kg, _, err := processHTTPStatus(tc.resp, tc.body)
+		ctx := context.Background()
+		_, kg, _, err := processHTTPStatus(ctx, tc.resp, tc.body)
 
 		if kg != tc.keepgoing {
 			t.Errorf("keepgoing value returned %t but expected %t", kg, tc.keepgoing)

--- a/otlpclient/otlp_client_null.go
+++ b/otlpclient/otlp_client_null.go
@@ -1,0 +1,31 @@
+package otlpclient
+
+import (
+	"context"
+
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// NullClient is an OTLP client backend for non-recording mode that drops
+// all data and never returns errors.
+type NullClient struct{}
+
+// NewNullClient returns a fresh NullClient ready to Start.
+func NewNullClient(config Config) *NullClient {
+	return &NullClient{}
+}
+
+// Start fulfills the interface and does nothing.
+func (nc *NullClient) Start(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+// UploadTraces fulfills the interface and does nothing.
+func (nc *NullClient) UploadTraces(ctx context.Context, rsps []*tracepb.ResourceSpans) (context.Context, error) {
+	return ctx, nil
+}
+
+// Stop fulfills the interface and does nothing.
+func (gc *NullClient) Stop(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}

--- a/otlpclient/protobuf_span.go
+++ b/otlpclient/protobuf_span.go
@@ -261,6 +261,10 @@ func SpanAttributesToStringMap(span *tracepb.Span) map[string]string {
 // ResourceAttributesToStringMap converts the ResourceSpan's resource attributes to a string map.
 // Only used by tests for now.
 func ResourceAttributesToStringMap(rss *tracepb.ResourceSpans) map[string]string {
+	if rss == nil {
+		return map[string]string{}
+	}
+
 	out := make(map[string]string)
 	for _, attr := range rss.Resource.Attributes {
 		out[attr.Key] = AttrValueToString(attr)


### PR DESCRIPTION
#226 is asking for something I've wanted to do for a while. The first step in making this possible is to plumb context through the OTLP clients, so that there's a place to tunnel errors in and out so they can be displayed. This also presents a path to eliminate the final remaining global in `otlpclient.Diag` and replace it with context tunneling.

This PR also contains the addition of `otlpclient/otlp_client_null.go` that implements a non-recording client. While doing the context work I noticed I forgot to have CLI commands stop their clients. After adding that, otel-cli started panicing on nil pointers because the client was nil. NullClient fixes this.

Added `otel-cli status --canary-count 1 --canary-interval 10ms` functionality for sending multiple canaries.