### PR TITLE
fill in some testing gaps, fix grpc headers

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -61,6 +61,7 @@ type Results struct {
 	Diagnostics otlpclient.Diagnostics `json:"diagnostics"`
 	// these are specific to tests...
 	ServerMeta    map[string]string
+	Headers       map[string]string // headers sent by the client
 	ResourceSpans *tracepb.ResourceSpans
 	CliOutput     string         // merged stdout and stderr
 	CliOutputRe   *regexp.Regexp // regular expression to clean the output before comparison
@@ -947,6 +948,67 @@ var suites = []FixtureSuite{
 					ParsedTimeoutMs:   1000,
 					Endpoint:          "*",
 					EndpointSource:    "*",
+				},
+			},
+		},
+	},
+	// full-system test --otlp-headers makes it to grpc/http servers
+	{
+		{
+			Name: "#231 gRPC headers for authentication",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"status",
+					"--endpoint", "{{endpoint}}",
+					"--protocol", "grpc",
+					"--otlp-headers", "x-otel-cli-otlpserver-token=abcdefgabcdefg",
+				},
+				ServerProtocol: grpcProtocol,
+			},
+			Expect: Results{
+				SpanCount: 1,
+				Config: otlpclient.DefaultConfig().
+					WithEndpoint("{{endpoint}}").
+					WithProtocol("grpc").
+					WithHeaders(map[string]string{
+						"x-otel-cli-otlpserver-token": "abcdefgabcdefg",
+					}),
+				Diagnostics: otlpclient.Diagnostics{
+					IsRecording:       true,
+					DetectedLocalhost: true,
+					NumArgs:           7,
+					ParsedTimeoutMs:   1000,
+					Endpoint:          "grpc://{{endpoint}}",
+					EndpointSource:    "general",
+				},
+			},
+		},
+		{
+			Name: "#231 http headers for authentication",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"status",
+					"--endpoint", "http://{{endpoint}}",
+					"--protocol", "http/protobuf",
+					"--otlp-headers", "x-otel-cli-otlpserver-token=abcdefgabcdefg",
+				},
+				ServerProtocol: httpProtocol,
+			},
+			Expect: Results{
+				SpanCount: 1,
+				Config: otlpclient.DefaultConfig().
+					WithEndpoint("http://{{endpoint}}").
+					WithProtocol("http/protobuf").
+					WithHeaders(map[string]string{
+						"x-otel-cli-otlpserver-token": "abcdefgabcdefg",
+					}),
+				Diagnostics: otlpclient.Diagnostics{
+					IsRecording:       true,
+					DetectedLocalhost: true,
+					NumArgs:           7,
+					ParsedTimeoutMs:   1000,
+					Endpoint:          "http://{{endpoint}}/v1/traces",
+					EndpointSource:    "general",
 				},
 			},
 		},

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -973,6 +973,12 @@ var suites = []FixtureSuite{
 					WithHeaders(map[string]string{
 						"x-otel-cli-otlpserver-token": "abcdefgabcdefg",
 					}),
+				Headers: map[string]string{
+					":authority":                  "{{endpoint}}\n",
+					"content-type":                "application/grpc\n",
+					"user-agent":                  "*",
+					"x-otel-cli-otlpserver-token": "abcdefgabcdefg\n",
+				},
 				Diagnostics: otlpclient.Diagnostics{
 					IsRecording:       true,
 					DetectedLocalhost: true,
@@ -1002,6 +1008,13 @@ var suites = []FixtureSuite{
 					WithHeaders(map[string]string{
 						"x-otel-cli-otlpserver-token": "abcdefgabcdefg",
 					}),
+				Headers: map[string]string{
+					"Content-Type":                "application/x-protobuf",
+					"Accept-Encoding":             "gzip",
+					"User-Agent":                  "Go-http-client/1.1",
+					"Content-Length":              "232",
+					"X-Otel-Cli-Otlpserver-Token": "abcdefgabcdefg",
+				},
 				Diagnostics: otlpclient.Diagnostics{
 					IsRecording:       true,
 					DetectedLocalhost: true,

--- a/main_test.go
+++ b/main_test.go
@@ -334,6 +334,13 @@ func checkHeaders(t *testing.T, fixture Fixture, results Results) {
 	injectMapVars(fixture.Endpoint, fixture.Expect.Headers, fixture.TlsData)
 	injectMapVars(fixture.Endpoint, results.Headers, fixture.TlsData)
 
+	for k, v := range fixture.Expect.Headers {
+		if v == "*" {
+			// overwrite value so cmp.Diff will ignore
+			results.Headers[k] = "*"
+		}
+	}
+
 	if diff := cmp.Diff(fixture.Expect.Headers, results.Headers); diff != "" {
 		t.Errorf("[%s] headers did not match expected (-want +got):\n%s", fixture.Name, diff)
 	}

--- a/otelcli/server_json.go
+++ b/otelcli/server_json.go
@@ -1,6 +1,7 @@
 package otelcli
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"log"
@@ -58,7 +59,7 @@ func doServerJson(cmd *cobra.Command, args []string) {
 
 // writeFile takes the spans and events and writes them out to json files in the
 // tid/sid/span.json and tid/sid/events.json files.
-func renderJson(span *tracepb.Span, events []*tracepb.Span_Event, ss *tracepb.ResourceSpans, meta map[string]string) bool {
+func renderJson(ctx context.Context, span *tracepb.Span, events []*tracepb.Span_Event, ss *tracepb.ResourceSpans, headers map[string]string, meta map[string]string) bool {
 	jsonSvr.spansSeen++ // count spans for exiting on --max-spans
 
 	// TODO: check for existence of outdir and error when it doesn't exist

--- a/otelcli/server_tui.go
+++ b/otelcli/server_tui.go
@@ -1,6 +1,7 @@
 package otelcli
 
 import (
+	"context"
 	"encoding/hex"
 	"log"
 	"math"
@@ -56,7 +57,7 @@ func doServerTui(cmd *cobra.Command, args []string) {
 
 // renderTui takes the given span and events, appends them to the in-memory
 // event list, sorts that, then prints it as a pterm table.
-func renderTui(span *tracepb.Span, events []*tracepb.Span_Event, rss *tracepb.ResourceSpans, meta map[string]string) bool {
+func renderTui(ctx context.Context, span *tracepb.Span, events []*tracepb.Span_Event, rss *tracepb.ResourceSpans, headers map[string]string, meta map[string]string) bool {
 	spanTraceId := hex.EncodeToString(span.TraceId)
 	if _, ok := tuiServer.traces[spanTraceId]; !ok {
 		tuiServer.traces[spanTraceId] = span

--- a/otlpclient/otlp_client_test.go
+++ b/otlpclient/otlp_client_test.go
@@ -1,8 +1,39 @@
 package otlpclient
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 )
+
+func TestErrorLists(t *testing.T) {
+	now := time.Now()
+
+	for _, tc := range []struct {
+		call func(context.Context) context.Context
+		want ErrorList
+	}{
+		{
+			call: func(ctx context.Context) context.Context {
+				err := fmt.Errorf("")
+				ctx, _ = SaveError(ctx, err)
+				return ctx
+			},
+			want: ErrorList{
+				TimestampedError{now, ""},
+			},
+		},
+	} {
+		ctx := context.Background()
+		ctx = tc.call(ctx)
+		list := GetErrorList(ctx)
+
+		if len(list) < len(tc.want) {
+			t.Error("not enough entries")
+		}
+	}
+}
 
 func TestParseEndpoint(t *testing.T) {
 	// func parseEndpoint(config Config) (*url.URL, string) {
@@ -71,5 +102,4 @@ func TestParseEndpoint(t *testing.T) {
 			t.Errorf("Expected source %q for test url %q but got %q", tc.wantSource, u.String(), src)
 		}
 	}
-
 }

--- a/otlpclient/otlp_client_test.go
+++ b/otlpclient/otlp_client_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestErrorLists(t *testing.T) {
@@ -17,7 +19,7 @@ func TestErrorLists(t *testing.T) {
 		{
 			call: func(ctx context.Context) context.Context {
 				err := fmt.Errorf("")
-				ctx, _ = SaveError(ctx, err)
+				ctx, _ = SaveError(ctx, now, err)
 				return ctx
 			},
 			want: ErrorList{
@@ -30,8 +32,14 @@ func TestErrorLists(t *testing.T) {
 		list := GetErrorList(ctx)
 
 		if len(list) < len(tc.want) {
-			t.Error("not enough entries")
+			t.Errorf("got %d errors but expected %d", len(tc.want), len(list))
 		}
+
+		// TODO: sort?
+		if diff := cmp.Diff(list, tc.want); diff != "" {
+			t.Errorf("error list mismatch (-want +got):\n%s", diff)
+		}
+
 	}
 }
 

--- a/otlpserver/httpserver.go
+++ b/otlpserver/httpserver.go
@@ -57,7 +57,12 @@ func (hs *HttpServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		"uri":          req.RequestURI,
 	}
 
-	done := doCallback(hs.callback, &msg, meta)
+	headers := make(map[string]string)
+	for k := range req.Header {
+		headers[k] = req.Header.Get(k)
+	}
+
+	done := doCallback(req.Context(), hs.callback, &msg, headers, meta)
 	if done {
 		go hs.StopWait()
 	}


### PR DESCRIPTION
While working on #227 a few gaps in testing were exposed, especially for gRPC and HTTP headers.

This PR adds functional tests for gRPC and HTTP header passing. Along the way I found the bug
in gRPC headers. When I wrote the gRPC client I assumed headers would be passed in with grpcOpts.
This was very wrong. I looked at the OTel collector, and it is passing them via grpc `metadata`. So I
fixed that.

Also added a test for the new ErrorList functionality. Just a single test for now but it's set up to add more.