### PR TITLE
add functionality for --force-parent-span-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ then config file, then environment variables.
 | --attrs              | OTEL_CLI_ATTRIBUTES                   | span_attributes          | k=v,a=b        |
 | --force-trace-id     | OTEL_CLI_FORCE_TRACE_ID               | force_trace_id           | 00112233445566778899aabbccddeeff |
 | --force-span-id      | OTEL_CLI_FORCE_SPAN_ID                | force_span_id            | beefcafefacedead |
-| --force-parent-span-id | OTEL_CLI_FORCE_PARENT_SPAN_ID       | force_parent_span_id     | parentbeefcafede |
+| --force-parent-span-id | OTEL_CLI_FORCE_PARENT_SPAN_ID       | force_parent_span_id     | p4r3ntb33fc4f3d3 |
 | --tp-required        | OTEL_CLI_TRACEPARENT_REQUIRED         | traceparent_required     | false          |
 | --tp-carrier         | OTEL_CLI_CARRIER_FILE                 | traceparent_carrier_file | filename.txt   |
 | --tp-ignore-env      | OTEL_CLI_IGNORE_ENV                   | traceparent_ignore_env   | false          |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ then config file, then environment variables.
 | --attrs              | OTEL_CLI_ATTRIBUTES                   | span_attributes          | k=v,a=b        |
 | --force-trace-id     | OTEL_CLI_FORCE_TRACE_ID               | force_trace_id           | 00112233445566778899aabbccddeeff |
 | --force-span-id      | OTEL_CLI_FORCE_SPAN_ID                | force_span_id            | beefcafefacedead |
+| --force-parent-span-id | OTEL_CLI_FORCE_PARENT_SPAN_ID       | force_parent_span_id     | parentbeefcafede |
 | --tp-required        | OTEL_CLI_TRACEPARENT_REQUIRED         | traceparent_required     | false          |
 | --tp-carrier         | OTEL_CLI_CARRIER_FILE                 | traceparent_carrier_file | filename.txt   |
 | --tp-ignore-env      | OTEL_CLI_IGNORE_ENV                   | traceparent_ignore_env   | false          |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ then config file, then environment variables.
 | --attrs              | OTEL_CLI_ATTRIBUTES                   | span_attributes          | k=v,a=b        |
 | --force-trace-id     | OTEL_CLI_FORCE_TRACE_ID               | force_trace_id           | 00112233445566778899aabbccddeeff |
 | --force-span-id      | OTEL_CLI_FORCE_SPAN_ID                | force_span_id            | beefcafefacedead |
-| --force-parent-span-id | OTEL_CLI_FORCE_PARENT_SPAN_ID       | force_parent_span_id     | p4r3ntb33fc4f3d3 |
+| --force-parent-span-id | OTEL_CLI_FORCE_PARENT_SPAN_ID       | force_parent_span_id     | eeeeeeb33fc4f3d3 |
 | --tp-required        | OTEL_CLI_TRACEPARENT_REQUIRED         | traceparent_required     | false          |
 | --tp-carrier         | OTEL_CLI_CARRIER_FILE                 | traceparent_carrier_file | filename.txt   |
 | --tp-ignore-env      | OTEL_CLI_IGNORE_ENV                   | traceparent_ignore_env   | false          |

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -932,7 +932,7 @@ var suites = []FixtureSuite{
 					"--endpoint", "{{endpoint}}",
 					"--force-trace-id", "00112233445566778899aabbccddeeff",
 					"--force-span-id", "beefcafefacedead",
-					"--force-parent-span-id", "parentbeefcafede",
+					"--force-parent-span-id", "p4r3ntb33fc4f3d3",
 				},
 			},
 			Expect: Results{
@@ -940,7 +940,7 @@ var suites = []FixtureSuite{
 				SpanData: map[string]string{
 					"trace_id":       "00112233445566778899aabbccddeeff",
 					"span_id":        "beefcafefacedead",
-					"parent_span_id": "parentbeefcafede",
+					"parent_span_id": "p4r3ntb33fc4f3d3",
 				},
 				SpanCount: 1,
 				Diagnostics: otlpclient.Diagnostics{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -922,23 +922,25 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
-	// --force-trace-id and --force-span-id allow setting/forcing custom trace & span ids
+	// --force-trace-id, --force-span-id and --force-parent-span-id allow setting/forcing custom trace, span and parent span ids
 	{
 		{
-			Name: "forced trace & span ids",
+			Name: "forced trace, span and parent span ids",
 			Config: FixtureConfig{
 				CliArgs: []string{
 					"status",
 					"--endpoint", "{{endpoint}}",
 					"--force-trace-id", "00112233445566778899aabbccddeeff",
 					"--force-span-id", "beefcafefacedead",
+					"--force-parent-span-id", "parentbeefcafede",
 				},
 			},
 			Expect: Results{
 				Config: otlpclient.DefaultConfig().WithEndpoint("{{endpoint}}"),
 				SpanData: map[string]string{
-					"trace_id": "00112233445566778899aabbccddeeff",
-					"span_id":  "beefcafefacedead",
+					"trace_id":       "00112233445566778899aabbccddeeff",
+					"span_id":        "beefcafefacedead",
+					"parent_span_id": "parentbeefcafede",
 				},
 				SpanCount: 1,
 				Diagnostics: otlpclient.Diagnostics{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -930,6 +930,7 @@ var suites = []FixtureSuite{
 				CliArgs: []string{
 					"status",
 					"--endpoint", "{{endpoint}}",
+					"--fail",
 					"--force-trace-id", "00112233445566778899aabbccddeeff",
 					"--force-span-id", "beefcafefacedead",
 					"--force-parent-span-id", "e4e3eeb33fc4f3d3",
@@ -944,7 +945,7 @@ var suites = []FixtureSuite{
 				},
 				SpanCount: 1,
 				Diagnostics: otlpclient.Diagnostics{
-					NumArgs:           7,
+					NumArgs:           10,
 					IsRecording:       true,
 					DetectedLocalhost: true,
 					ParsedTimeoutMs:   1000,

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -940,7 +940,7 @@ var suites = []FixtureSuite{
 				SpanData: map[string]string{
 					"trace_id":       "00112233445566778899aabbccddeeff",
 					"span_id":        "beefcafefacedead",
-					"parent_span_id": "p4r3ntb33fc4f3d3",
+					"parent_span_id": "e4e3eeb33fc4f3d3",
 				},
 				SpanCount: 1,
 				Diagnostics: otlpclient.Diagnostics{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -932,7 +932,7 @@ var suites = []FixtureSuite{
 					"--endpoint", "{{endpoint}}",
 					"--force-trace-id", "00112233445566778899aabbccddeeff",
 					"--force-span-id", "beefcafefacedead",
-					"--force-parent-span-id", "p4r3ntb33fc4f3d3",
+					"--force-parent-span-id", "e4e3eeb33fc4f3d3",
 				},
 			},
 			Expect: Results{

--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -150,9 +150,10 @@ func addSpanParams(cmd *cobra.Command, config *otlpclient.Config) {
 	// --kind / -k
 	cmd.Flags().StringVarP(&config.Kind, "kind", "k", defaults.Kind, "set the trace kind, e.g. internal, server, client, producer, consumer")
 
-	// expert options: --force-trace-id, --force-span-id allow setting custom trace & span ids
+	// expert options: --force-trace-id, --force-span-id, --force-parent-span-id allow setting custom trace, span and parent span ids
 	cmd.Flags().StringVar(&config.ForceTraceId, "force-trace-id", defaults.ForceTraceId, "expert: force the trace id to be the one provided in hex")
 	cmd.Flags().StringVar(&config.ForceSpanId, "force-span-id", defaults.ForceSpanId, "expert: force the span id to be the one provided in hex")
+	cmd.Flags().StringVar(&config.ForceParentSpanId, "force-parent-span-id", defaults.ForceParentSpanId, "expert: force the parent span id to be the one provided in hex")
 
 	addSpanStatusParams(cmd, config)
 }

--- a/otlpclient/config.go
+++ b/otlpclient/config.go
@@ -42,6 +42,7 @@ func DefaultConfig() Config {
 		Kind:                         "client",
 		ForceTraceId:                 "",
 		ForceSpanId:                  "",
+		ForceParentSpanId:            "",
 		Attributes:                   map[string]string{},
 		TraceparentCarrierFile:       "",
 		TraceparentIgnoreEnv:         false,
@@ -91,6 +92,7 @@ type Config struct {
 	StatusCode        string            `json:"span_status_code" env:"OTEL_CLI_STATUS_CODE"`
 	StatusDescription string            `json:"span_status_description" env:"OTEL_CLI_STATUS_DESCRIPTION"`
 	ForceSpanId       string            `json:"force_span_id" env:"OTEL_CLI_FORCE_SPAN_ID"`
+	ForceParentSpanId string            `json:"force_parent_span_id" env:"OTEL_CLI_FORCE_PARENT_SPAN_ID"`
 	ForceTraceId      string            `json:"force_trace_id" env:"OTEL_CLI_FORCE_TRACE_ID"`
 
 	TraceparentCarrierFile string `json:"traceparent_carrier_file" env:"OTEL_CLI_CARRIER_FILE"`

--- a/otlpclient/protobuf_span.go
+++ b/otlpclient/protobuf_span.go
@@ -95,7 +95,7 @@ func NewProtobufSpanWithConfig(c Config) *tracepb.Span {
 		span.SpanId = emptySpanId
 	}
 
-	// --force-trace-id and --force-span-id let the user set their own trace & span ids
+	// --force-trace-id, --force-span-id and --force-parent-span-id let the user set their own trace, span & parent span ids
 	// these work in non-recording mode and will stomp trace id from the traceparent
 	var err error
 	if c.ForceTraceId != "" {
@@ -104,6 +104,10 @@ func NewProtobufSpanWithConfig(c Config) *tracepb.Span {
 	}
 	if c.ForceSpanId != "" {
 		span.SpanId, err = parseHex(c.ForceSpanId, 8)
+		c.SoftFailIfErr(err)
+	}
+	if c.ForceParentSpanId != "" {
+		span.ParentSpanId, err = parseHex(c.ForceParentSpanId, 8)
 		c.SoftFailIfErr(err)
 	}
 

--- a/otlpclient/protobuf_span.go
+++ b/otlpclient/protobuf_span.go
@@ -301,7 +301,7 @@ func SpanToStringMap(span *tracepb.Span, rss *tracepb.ResourceSpans) map[string]
 	return map[string]string{
 		"trace_id":           hex.EncodeToString(span.GetTraceId()),
 		"span_id":            hex.EncodeToString(span.GetSpanId()),
-		"parent":             hex.EncodeToString(span.GetParentSpanId()),
+		"parent_span_id":     hex.EncodeToString(span.GetParentSpanId()),
 		"name":               span.Name,
 		"kind":               SpanKindIntToString(span.GetKind()),
 		"start":              strconv.FormatUint(span.StartTimeUnixNano, 10),


### PR DESCRIPTION
similar to `--force-trace-id` and `--force-span-id`, this PR adds the ability to specify `--force-parent-span-id` or `OTEL_CLI_FORCE_PARENT_SPAN_ID` to override a parent span id.

cc/ https://github.com/equinix-labs/otel-cli/issues/240