### PR TITLE
allow setting attrs at the end of a backgrounded trace

### DIFF
--- a/otelcli/span_end.go
+++ b/otelcli/span_end.go
@@ -16,7 +16,8 @@ func spanEndCmd(config *Config) *cobra.Command {
 
 See: otel-cli span background
 
-	otel-cli span end --sockdir $sockdir
+	otel-cli span end --sockdir $sockdir \
+		--attrs "output.length=$(wc -l < output.txt | sed -e 's/^[[:space:]]*//')
 `,
 		Run: doSpanEnd,
 	}
@@ -32,6 +33,7 @@ See: otel-cli span background
 	cmd.Flags().StringVar(&config.SpanEndTime, "end", defaults.SpanEndTime, "an Unix epoch or RFC3339 timestamp for the end of the span")
 
 	addSpanStatusParams(&cmd, config)
+	addAttrParams(&cmd, config)
 
 	return &cmd
 }
@@ -41,6 +43,7 @@ func doSpanEnd(cmd *cobra.Command, args []string) {
 	client, shutdown := createBgClient(config)
 
 	rpcArgs := BgEnd{
+		Attributes: config.Attributes,
 		StatusCode: config.StatusCode,
 		StatusDesc: config.StatusDescription,
 	}

--- a/otlpclient/protobuf_span.go
+++ b/otlpclient/protobuf_span.go
@@ -186,7 +186,6 @@ func StringMapAttrsToProtobuf(attributes map[string]string) []*commonpb.KeyValue
 }
 
 // SpanAttributesToStringMap converts the span's attributes to a string map.
-// Only used by tests for now.
 func SpanAttributesToStringMap(span *tracepb.Span) map[string]string {
 	out := make(map[string]string)
 	for _, attr := range span.Attributes {


### PR DESCRIPTION
I wanted to be able to add additional attributes at the end of a backgrounded span, so that outputs from whatever was run during the span could be included.

With this change, attributes which are defined at the start of the span are added to and overwritten by attributes supplied at the end of the span.