### PR TITLE
Don't fail on err in exec

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -370,19 +370,22 @@ var suites = []FixtureSuite{
 		},
 	},
         // exec false reports a span
-        { 
-                {
-                        Name: "#258 Commands that exit with a non-zero exit code should report a span",
-                        Config: FixtureConfig{
-                                CliArgs: []string{"exec", "--endpoint", "{{endpoint}}", "--", "false"},
-                        },
-                        Expect: Results{
-                                SpanCount: 1,
-                                CommandFailed: true,
-				Config:    otelcli.DefaultConfig().WithEndpoint("grpc://{{endpoint}}"),
-                        },
-                },
-        },
+        // { 
+        //         {
+        //                 Name: "#258 Commands that exit with a non-zero exit code should report a span",
+        //                 Config: FixtureConfig{
+        //                         CliArgs: []string{"exec", "--endpoint", "{{endpoint}}", "--", "false"},
+        //                 },
+        //                 Expect: Results{
+        //                         SpanCount: 1,
+        //                         CliOutput: "",
+        //                         Diagnostics: otelcli.Diagnostics{
+        //                                 ExecExitCode: 1,
+        //                         },
+	// 			Config:    otelcli.DefaultConfig().WithEndpoint("grpc://{{endpoint}}"),
+        //                 },
+        //         },
+        // },
 	// regression tests
 	{
 		{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -369,6 +369,20 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
+        // exec false reports a span
+        { 
+                {
+                        Name: "#258 Commands that exit with a non-zero exit code should report a span",
+                        Config: FixtureConfig{
+                                CliArgs: []string{"exec", "--endpoint", "{{endpoint}}", "--", "false"},
+                        },
+                        Expect: Results{
+                                SpanCount: 1,
+                                CommandFailed: true,
+				Config:    otelcli.DefaultConfig().WithEndpoint("grpc://{{endpoint}}"),
+                        },
+                },
+        },
 	// regression tests
 	{
 		{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -70,7 +70,8 @@ type Results struct {
 	SpanCount     int            // number of spans received
 	EventCount    int            // number of events received
 	TimedOut      bool           // true when test timed out
-	CommandFailed bool           // otel-cli failed / was killed
+	CommandFailed bool           // otel-cli was killed, did not exit() on its own
+	ExitCode      int            // the process exit code returned by otel-cli
 	Span          *tracepb.Span
 	SpanEvents    []*tracepb.Span_Event
 }
@@ -326,8 +327,8 @@ var suites = []FixtureSuite{
 				},
 			},
 			Expect: Results{
-				Config:        otelcli.DefaultConfig(),
-				CommandFailed: true,
+				Config:   otelcli.DefaultConfig(),
+				ExitCode: 1,
 				// strips the date off the log line before comparing to expectation
 				CliOutputRe: regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `),
 				CliOutput: "Error while loading environment variables: could not parse OTEL_CLI_VERBOSE value " +
@@ -369,23 +370,7 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
-        // exec false reports a span
-        // { 
-        //         {
-        //                 Name: "#258 Commands that exit with a non-zero exit code should report a span",
-        //                 Config: FixtureConfig{
-        //                         CliArgs: []string{"exec", "--endpoint", "{{endpoint}}", "--", "false"},
-        //                 },
-        //                 Expect: Results{
-        //                         SpanCount: 1,
-        //                         CliOutput: "",
-        //                         Diagnostics: otelcli.Diagnostics{
-        //                                 ExecExitCode: 1,
-        //                         },
-	// 			Config:    otelcli.DefaultConfig().WithEndpoint("grpc://{{endpoint}}"),
-        //                 },
-        //         },
-        // },
+
 	// regression tests
 	{
 		{
@@ -480,6 +465,23 @@ var suites = []FixtureSuite{
 					Endpoint:          "http://{{endpoint}}/mycollector/x/1",
 					EndpointSource:    "signal",
 				},
+			},
+		},
+		{
+			Name: "#258 Commands that exit with a non-zero exit code should report a span",
+			Config: FixtureConfig{
+				CliArgs: []string{"exec",
+					"--endpoint", "{{endpoint}}",
+					"--verbose", "--fail",
+					"--", "false",
+				},
+			},
+			Expect: Results{
+				ExitCode:      1,
+				SpanCount:     1,
+				CliOutput:     "",
+				CommandFailed: false, // otel-cli should exit voluntarily in this case
+				Config:        otelcli.DefaultConfig().WithEndpoint("grpc://{{endpoint}}"),
 			},
 		},
 	},
@@ -847,10 +849,9 @@ var suites = []FixtureSuite{
 				TestTimeoutMs: 1000,
 			},
 			Expect: Results{
-				CommandFailed: true,
-				CliOutputRe:   regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `),
-				CliOutput:     "invalid protocol setting \"xxx\"\n",
-				Config:        otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
+				CliOutputRe: regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `),
+				CliOutput:   "invalid protocol setting \"xxx\"\n",
+				Config:      otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
 				Diagnostics: otelcli.Diagnostics{
 					IsRecording:       false,
 					NumArgs:           7,
@@ -858,6 +859,7 @@ var suites = []FixtureSuite{
 					ParsedTimeoutMs:   1000,
 					Endpoint:          "*",
 					EndpointSource:    "*",
+					ExecExitCode:      1,
 				},
 				SpanCount: 0,
 			},
@@ -936,10 +938,10 @@ var suites = []FixtureSuite{
 				},
 			},
 			Expect: Results{
-				CommandFailed: true,
-				CliOutputRe:   regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `),
-				CliOutput:     "invalid protocol setting \"roflcopter\"\n",
-				Config:        otelcli.DefaultConfig().WithEndpoint("http://{{endpoint}}"),
+				ExitCode:    1,
+				CliOutputRe: regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `),
+				CliOutput:   "invalid protocol setting \"roflcopter\"\n",
+				Config:      otelcli.DefaultConfig().WithEndpoint("http://{{endpoint}}"),
 				Diagnostics: otelcli.Diagnostics{
 					IsRecording:       false,
 					NumArgs:           3,

--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -94,7 +94,8 @@ func doExec(cmd *cobra.Command, args []string) {
 	}
 
 	if err := child.Run(); err != nil {
-		config.SoftFail("command failed: %s", err)
+                span.SetStatus(codes.Error)
+                span.RecordError(err)
 	}
 	span.EndTimeUnixNano = uint64(time.Now().UnixNano())
 

--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"github.com/equinix-labs/otel-cli/otlpclient"
 	"github.com/spf13/cobra"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 // execCmd sets up the `otel-cli exec` command
@@ -95,10 +95,10 @@ func doExec(cmd *cobra.Command, args []string) {
 	}
 
 	if err := child.Run(); err != nil {
-                span.Status = & tracev1.Status {
-                        Message: fmt.Sprintln("exec command failed: ", err),
-                        Code: tracev1.Status_STATUS_CODE_ERROR,
-                }
+		span.Status = &tracev1.Status{
+			Message: fmt.Sprintf("exec command failed: %s", err),
+			Code:    tracev1.Status_STATUS_CODE_ERROR,
+		}
 	}
 	span.EndTimeUnixNano = uint64(time.Now().UnixNano())
 

--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"github.com/equinix-labs/otel-cli/otlpclient"
 	"github.com/spf13/cobra"
 )
@@ -94,8 +95,10 @@ func doExec(cmd *cobra.Command, args []string) {
 	}
 
 	if err := child.Run(); err != nil {
-                span.SetStatus(codes.Error)
-                span.RecordError(err)
+                span.Status = & tracev1.Status {
+                        Message: fmt.Sprintln("exec command failed: ", err),
+                        Code: tracev1.Status_STATUS_CODE_ERROR,
+                }
 	}
 	span.EndTimeUnixNano = uint64(time.Now().UnixNano())
 


### PR DESCRIPTION
Fixes #258 

I'm having a hard time writing a test for this. I have verified that this change makes the code do what I want - spans show up in Honeycomb and `otel-cli exec false` has a non-0 exit code.

```
λ otel-cli exec --name "false" false
λ echo $?
1
```

However, the test does not appear to work? Locally it tells me that no spans were recorded.