### PR TITLE
fix: only consider partial if spans were rejected

### DIFF
--- a/otlpclient/otlp_client_http.go
+++ b/otlpclient/otlp_client_http.go
@@ -98,7 +98,7 @@ func processHTTPStatus(ctx context.Context, resp *http.Response, body []byte) (c
 			return ctx, false, 0, fmt.Errorf("unmarshal of server response failed: %w", err)
 		}
 
-		if partial := etsr.GetPartialSuccess(); partial != nil {
+		if partial := etsr.GetPartialSuccess(); partial != nil && partial.RejectedSpans > 0 {
 			// spec says to stop retrying and drop rejected spans
 			return ctx, false, 0, fmt.Errorf("partial success. %d spans were rejected", partial.GetRejectedSpans())
 


### PR DESCRIPTION
I am rather new to otel but I'm submitting a span using the following and getting nothing back, but with --verbose it says a partial response and throws an error which is wrong. The remote accepted all spans.

```console
otel-cli span -s "test1" -n "test2" --tp-export --tp-print
```

This fixes it so that it will only error IF a span is rejected.

