### PR TITLE
add tests for attrs at end of bg trace

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -758,7 +758,6 @@ var suites = []FixtureSuite{
 				CliArgs: []string{
 					"span", "end",
 					"--sockdir", ".",
-					// these are validated by checkfuncs defined above ^^
 					"--attrs", "ghi=jkl,abc=def",
 				},
 			},
@@ -799,7 +798,6 @@ var suites = []FixtureSuite{
 				CliArgs: []string{
 					"span", "end",
 					"--sockdir", ".",
-					// these are validated by checkfuncs defined above ^^
 					"--attrs", "ghi=jkl",
 				},
 			},
@@ -840,7 +838,6 @@ var suites = []FixtureSuite{
 				CliArgs: []string{
 					"span", "end",
 					"--sockdir", ".",
-					// these are validated by checkfuncs defined above ^^
 					"--attrs", "ghi=jkl,abc=def",
 				},
 			},

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -731,6 +731,88 @@ var suites = []FixtureSuite{
 			Expect: Results{Config: otelcli.DefaultConfig()},
 		},
 	},
+	// otel-cli span background, add attrs on span end
+	{
+		{
+			Name: "otel-cli span background (recording) with attrs added on end",
+			Config: FixtureConfig{
+				CliArgs:       []string{"span", "background", "--timeout", "1s", "--sockdir", "."},
+				Env:           map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "{{endpoint}}"},
+				TestTimeoutMs: 2000,
+				Background:    true,
+				Foreground:    false,
+			},
+			Expect: Results{
+				Config: otelcli.DefaultConfig(),
+				SpanData: map[string]string{
+					"span_id":    "*",
+					"trace_id":   "*",
+					"attributes": `abc=def,ghi=jkl`, // weird format because of limitation in OTLP server
+				},
+				SpanCount: 1,
+			},
+		},
+		{
+			Name: "otel-cli span end",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"span", "end",
+					"--sockdir", ".",
+					// these are validated by checkfuncs defined above ^^
+					"--attrs", "ghi=jkl,abc=def",
+				},
+			},
+			Expect: Results{Config: otelcli.DefaultConfig()},
+		},
+		{
+			Name: "otel-cli span background (recording) with attrs added on end",
+			Config: FixtureConfig{
+				Foreground: true, // fg
+			},
+			Expect: Results{Config: otelcli.DefaultConfig()},
+		},
+	},
+	// otel-cli span background, modify and add attrs on span end
+	{
+		{
+			Name: "otel-cli span background (recording) with attrs modified and added on end",
+			Config: FixtureConfig{
+				CliArgs:       []string{"span", "background", "--timeout", "1s", "--sockdir", ".", "--attrs", "abc=123"},
+				Env:           map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "{{endpoint}}"},
+				TestTimeoutMs: 2000,
+				Background:    true,
+				Foreground:    false,
+			},
+			Expect: Results{
+				Config: otelcli.DefaultConfig(),
+				SpanData: map[string]string{
+					"span_id":    "*",
+					"trace_id":   "*",
+					"attributes": `abc=def,ghi=jkl`, // weird format because of limitation in OTLP server
+				},
+				SpanCount: 1,
+			},
+		},
+		{
+			Name: "otel-cli span end",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"span", "end",
+					"--sockdir", ".",
+					// these are validated by checkfuncs defined above ^^
+					"--attrs", "ghi=jkl,abc=def",
+				},
+			},
+			Expect: Results{Config: otelcli.DefaultConfig()},
+		},
+		{
+			Name: "otel-cli span background (recording) with attrs modified and added on end",
+			Config: FixtureConfig{
+				Foreground: true, // fg
+			},
+			Expect: Results{Config: otelcli.DefaultConfig()},
+		},
+	},
 	// otel-cli exec runs echo
 	{
 		{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -772,6 +772,47 @@ var suites = []FixtureSuite{
 			Expect: Results{Config: otelcli.DefaultConfig()},
 		},
 	},
+	// otel-cli span background with attrs, append attrs on span end
+	{
+		{
+			Name: "otel-cli span background (recording) with attrs append on end",
+			Config: FixtureConfig{
+				CliArgs:       []string{"span", "background", "--timeout", "1s", "--sockdir", ".", "--attrs", "abc=def"},
+				Env:           map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "{{endpoint}}"},
+				TestTimeoutMs: 2000,
+				Background:    true,
+				Foreground:    false,
+			},
+			Expect: Results{
+				Config: otelcli.DefaultConfig(),
+				SpanData: map[string]string{
+					"span_id":    "*",
+					"trace_id":   "*",
+					"attributes": `abc=def,ghi=jkl`, // weird format because of limitation in OTLP server
+				},
+				SpanCount: 1,
+			},
+		},
+		{
+			Name: "otel-cli span end",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"span", "end",
+					"--sockdir", ".",
+					// these are validated by checkfuncs defined above ^^
+					"--attrs", "ghi=jkl",
+				},
+			},
+			Expect: Results{Config: otelcli.DefaultConfig()},
+		},
+		{
+			Name: "otel-cli span background (recording) with attrs append on end",
+			Config: FixtureConfig{
+				Foreground: true, // fg
+			},
+			Expect: Results{Config: otelcli.DefaultConfig()},
+		},
+	},
 	// otel-cli span background, modify and add attrs on span end
 	{
 		{

--- a/otelcli/span_background_server.go
+++ b/otelcli/span_background_server.go
@@ -162,6 +162,7 @@ func (bgs *bgServer) Run() {
 // Shutdown does a controlled shutdown of the background server. Blocks until
 // the server is turned down cleanly and it's safe to exit.
 func (bgs *bgServer) Shutdown() {
+	os.Remove(bgs.sockfile)
 	close(bgs.quit)
 	bgs.listener.Close()
 	bgs.wg.Wait()


### PR DESCRIPTION
Adds a couple of tests as per https://github.com/equinix-labs/otel-cli/pull/255#issuecomment-1717689924

- adding attributes only at the end
- appending attributes to a span which already has attributes
- modifying an existing attribute and appending new attributes

Let me know if there is another case which should be covered or if these should be more thorough.