### PR TITLE
fix timeouts

### DIFF
--- a/otelcli/span_background.go
+++ b/otelcli/span_background.go
@@ -133,6 +133,10 @@ func doSpanBackground(cmd *cobra.Command, args []string) {
 	bgs.Run()
 
 	span.EndTimeUnixNano = uint64(time.Now().UnixNano())
+
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(config.GetTimeout()))
+	defer cancel()
+
 	_, err := otlpclient.SendSpan(ctx, client, config, span)
 	if err != nil {
 		config.SoftFail("Sending span failed: %s", err)

--- a/otelcli/status.go
+++ b/otelcli/status.go
@@ -1,6 +1,7 @@
 package otelcli
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -60,6 +61,8 @@ func doStatus(cmd *cobra.Command, args []string) {
 
 	ctx := cmd.Context()
 	config := getConfig(ctx)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(config.GetTimeout()))
+	defer cancel()
 	ctx, client := StartClient(ctx, config)
 
 	env := make(map[string]string)

--- a/otlpclient/otlp_client.go
+++ b/otlpclient/otlp_client.go
@@ -193,9 +193,7 @@ func SaveError(ctx context.Context, t time.Time, err error) (context.Context, er
 func retry(ctx context.Context, config OTLPConfig, fun retryFun) (context.Context, error) {
 	deadline, haveDL := ctx.Deadline()
 	if !haveDL {
-		// TODO: upstream callers should set their own deadlines but that's out of scope
-		// for my current PR, so this maintains the old behavor
-		deadline = time.Now().Add(config.GetTimeout())
+		return ctx, fmt.Errorf("BUG in otel-cli: no deadline set before retry()")
 	}
 	sleep := time.Duration(0)
 	for {


### PR DESCRIPTION
In my previous PR, I changed otlpclient.retry() to add a deadline when one is missing. This would have been fine if it used the old config.StartupTime but that's gone so I used time.Now(). The problem is, it'll get a new time in the future for every call to retry and never stop.

Clearly this needs more testing but for now let's fix it what wasn't broken before.