### PR TITLE
switch to alpine:latest base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.4.2] - 2023-12-01
+
+The Docker container now builds off `alpine:latest` instead of `scratch`. This
+makes the default certificate store included with Alpine available to otel-cli.
+
+### Changed
+
+- switch release Dockerfile to base off alpine:latest
+
 ## [0.4.1] - 2023-10-16
 
 Mostly small but impactful changes to `otel-cli exec`.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ On most platforms the easiest way is a go get:
 go install github.com/equinix-labs/otel-cli@latest
 ```
 
+Docker images are published for each otel-cli release as well:
+
+```shell
+docker pull ghcr.io/equinix-labs/otel-cli:latest
+docker run ghcr.io/equinix-labs/otel-cli:latest status
+```
+
 To use the brew tap e.g. on MacOS:
 
 ```shell
@@ -154,6 +161,18 @@ embedding commas will work fine.
 ```shell
 otel-cli span --attrs item1=value1,\"item2=value2,value3\",item3=value4
 otel-cli span --attrs 'item1=value1,"item2=value2,value3",item3=value4'
+```
+
+### Docker TLS Certificates
+
+As of release 0.4.2, otel-cli containers are built off the latest Alpine base
+image which contains the base CA certificate bundles. In over to override
+these for e.g. a self-signed certificate, the best bet is to volume mount your
+own /etc/ssl into the container, and it should get picked up by otel-cli and Go's
+TLS libraries.
+
+```shell
+docker run -v /etc/ssl:/etc/ssl ghcr.io/equinix-labs/otel-cli:latest status
 ```
 
 ## Easy local dev

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,6 +1,9 @@
 # While the top-level Dockerfile is set up for local development on otel-cli,
-# this Dockerfile is only for release. otel-cli containers should contain only
-# the otel-cli static binary and nothing else.
-FROM scratch
+# this Dockerfile is only for release.
+#
+# We use the Alpine base image to get the TLS trust store and not much else.
+# The ca-certificates-bundle packet is pre-installed in the base so no
+# additional packages are required.
+FROM alpine:latest
 ENTRYPOINT ["/otel-cli"]
 COPY otel-cli /


### PR DESCRIPTION
Switches the base container image to alpine:latest instead of scratch so that there is a certificate store available by default.