### PR TITLE
#81 template traceparent into exec command args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.4.3] - 2024-02-23
+
+Add injection of `{{traceparent}}` to `otel-cli exec`.
+
+### Added
+
+- `otel-cli exec echo {{traceparent}}` is now supported to pass traceparent to child process
+
 ## [0.4.2] - 2023-12-01
 
 The Docker container now builds off `alpine:latest` instead of `scratch`. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## [0.4.3] - 2024-02-23
+## [0.4.3] - 2024-03-11
 
-Add injection of `{{traceparent}}` to `otel-cli exec`.
+Add injection of `{{traceparent}}` to `otel-cli exec` as default behavior, along with
+the `otel-cli exec --tp-disable-inject` to turn it off (old behavior).
 
 ### Added
 
 - `otel-cli exec echo {{traceparent}}` is now supported to pass traceparent to child process
+- `otel-cli exec --tp-disable-inject` will disable this new default behavior
 
 ## [0.4.2] - 2023-12-01
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ otel-cli exec --kind producer "otel-cli exec --kind consumer sleep 1"
 # used by span and exec. use --tp-ignore-env to ignore it even when present
 export TRACEPARENT=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 
+# you can pass the traceparent to a child via arguments as well
+# {{traceparent}} in any of the command's arguments will be replaced with the traceparent string
+otel-cli exec --name "curl api" -- \
+   curl -H 'traceparent: {{traceparent}}' https://myapi.com/v1/coolstuff
+
 # create a span with a custom start/end time using either RFC3339,
 # same with the nanosecond extension, or Unix epoch, with/without nanos
 otel-cli span --start 2021-03-24T07:28:05.12345Z --end 2021-03-24T07:30:08.0001Z

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -915,6 +915,7 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
+	// otel-cli exec echo "{{traceparent}}" and otel-cli exec --tp-disable-inject
 	{
 		{
 			Name: "otel-cli exec with arg injection injects the traceparent",
@@ -931,8 +932,6 @@ var suites = []FixtureSuite{
 				SpanCount: 1,
 			},
 		},
-	},
-	{
 		{
 			Name: "otel-cli exec --tp-disable-inject returns the {{traceparent}} tag unmodified",
 			Config: FixtureConfig{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -917,7 +917,7 @@ var suites = []FixtureSuite{
 	},
 	{
 		{
-			Name: "otel-cli exec with arg injection",
+			Name: "otel-cli exec with arg injection injects the traceparent",
 			Config: FixtureConfig{
 				CliArgs: []string{
 					"exec", "--endpoint", "{{endpoint}}",
@@ -928,6 +928,24 @@ var suites = []FixtureSuite{
 			Expect: Results{
 				Config:    otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
 				CliOutput: "00-e39280f2980af3a8600ae98c74f2dabf-023eee2731392b4d-01\n",
+				SpanCount: 1,
+			},
+		},
+	},
+	{
+		{
+			Name: "otel-cli exec --tp-disable-inject returns the {{traceparent}} tag unmodified",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"exec", "--endpoint", "{{endpoint}}",
+					"--force-trace-id", "e39280f2980af3a8600ae98c74f2dabf", "--force-span-id", "023eee2731392b4d",
+					"--tp-disable-inject",
+					"--",
+					"echo", "{{traceparent}}"},
+			},
+			Expect: Results{
+				Config:    otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
+				CliOutput: "{{traceparent}}\n",
 				SpanCount: 1,
 			},
 		},

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -926,10 +926,9 @@ var suites = []FixtureSuite{
 					"echo", "{{traceparent}}"},
 			},
 			Expect: Results{
-				Config:      otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
-				CliOutputRe: regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `),
-				CliOutput:   "00-e39280f2980af3a8600ae98c74f2dabf-023eee2731392b4d-01\n",
-				SpanCount:   1,
+				Config:    otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
+				CliOutput: "00-e39280f2980af3a8600ae98c74f2dabf-023eee2731392b4d-01\n",
+				SpanCount: 1,
 			},
 		},
 	},

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -902,7 +902,7 @@ var suites = []FixtureSuite{
 	// otel-cli exec runs otel-cli exec
 	{
 		{
-			Name: "otel-cli span exec (nested)",
+			Name: "otel-cli exec (nested)",
 			Config: FixtureConfig{
 				CliArgs: []string{
 					"exec", "--name", "outer", "--endpoint", "{{endpoint}}", "--fail", "--verbose", "--",
@@ -912,6 +912,24 @@ var suites = []FixtureSuite{
 				Config:    otelcli.DefaultConfig(),
 				CliOutput: "hello world\n",
 				SpanCount: 2,
+			},
+		},
+	},
+	{
+		{
+			Name: "otel-cli exec with arg injection",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"exec", "--endpoint", "{{endpoint}}",
+					"--force-trace-id", "e39280f2980af3a8600ae98c74f2dabf", "--force-span-id", "023eee2731392b4d",
+					"--",
+					"echo", "{{traceparent}}"},
+			},
+			Expect: Results{
+				Config:      otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
+				CliOutputRe: regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `),
+				CliOutput:   "00-e39280f2980af3a8600ae98c74f2dabf-023eee2731392b4d-01\n",
+				SpanCount:   1,
 			},
 		},
 	},

--- a/otelcli/config.go
+++ b/otelcli/config.go
@@ -56,6 +56,7 @@ func DefaultConfig() Config {
 		BackgroundWait:               false,
 		BackgroundSkipParentPidCheck: false,
 		ExecCommandTimeout:           "",
+		ExecTpDisableInject:          false,
 		StatusCanaryCount:            1,
 		StatusCanaryInterval:         "",
 		SpanStartTime:                "now",
@@ -109,7 +110,8 @@ type Config struct {
 	BackgroundWait               bool   `json:"background_wait" env:""`
 	BackgroundSkipParentPidCheck bool   `json:"background_skip_parent_pid_check"`
 
-	ExecCommandTimeout string `json:"exec_command_timeout" env:"OTEL_CLI_EXEC_CMD_TIMEOUT"`
+	ExecCommandTimeout  string `json:"exec_command_timeout" env:"OTEL_CLI_EXEC_CMD_TIMEOUT"`
+	ExecTpDisableInject bool   `json:"exec_tp_disable_inject" env:"OTEL_CLI_EXEC_TP_DISALBE_INJECT"`
 
 	StatusCanaryCount    int    `json:"status_canary_count"`
 	StatusCanaryInterval string `json:"status_canary_interval"`
@@ -232,6 +234,7 @@ func (c Config) ToStringMap() map[string]string {
 		"background_wait":             strconv.FormatBool(c.BackgroundWait),
 		"background_skip_pid_check":   strconv.FormatBool(c.BackgroundSkipParentPidCheck),
 		"exec_command_timeout":        c.ExecCommandTimeout,
+		"exec_tp_disable_inject":      strconv.FormatBool(c.ExecTpDisableInject),
 		"span_start_time":             c.SpanStartTime,
 		"span_end_time":               c.SpanEndTime,
 		"event_name":                  c.EventName,


### PR DESCRIPTION
Adds a feature to `otel-cli exec` to make it easier to get a traceparent into the child's command line args.

solves #306 #81

```shell
export TRACEPARENT=00-5b28ee2bf1f1796cca65bef26fb90c35-9d699b596c3dced3-01
./otel-cli exec --endpoint localhost:4317 -- \
   curl --verbose -H 'traceparent: {{traceparent}}' http://tobert.org
```
```
*   Trying 45.33.3.11:80...
* Connected to tobert.org (45.33.3.11) port 80 (#0)
> GET / HTTP/1.1
> Host: tobert.org
> User-Agent: curl/7.81.0
> Accept: */*
> traceparent: 00-5b28ee2bf1f1796cca65bef26fb90c35-433d7e8620e9ccea-01
```