### PR TITLE
fix typo in exec envvar OTEL_CLI_EXEC_TP_DISABLE_INJECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.4.4] - 2024-03-11
+
+Fix a typo in the `OTEL_CLI_EXEC_TP_DISABLE_INJECT` envvar.
+
+### Changed
+
+- spell `DISALBE` correctly in `OTEL_CLI_EXEC_TP_DISABLE_INJECT`
+- adds a test for that
+
 ## [0.4.3] - 2024-03-11
 
 Add injection of `{{traceparent}}` to `otel-cli exec` as default behavior, along with

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -948,6 +948,24 @@ var suites = []FixtureSuite{
 				SpanCount: 1,
 			},
 		},
+		{
+			Name: "otel-cli exec returns the {{traceparent}} tag unmodified with OTEL_CLI_EXEC_TP_DISABLE_INJECT",
+			Config: FixtureConfig{
+				Env: map[string]string{
+					"OTEL_CLI_EXEC_TP_DISABLE_INJECT": "true",
+				},
+				CliArgs: []string{
+					"exec", "--endpoint", "{{endpoint}}",
+					"--force-trace-id", "e39280f2980af3a8600ae98c74f2dabf", "--force-span-id", "023eee2731392b4d",
+					"--",
+					"echo", "{{traceparent}}"},
+			},
+			Expect: Results{
+				Config:    otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
+				CliOutput: "{{traceparent}}\n",
+				SpanCount: 1,
+			},
+		},
 	},
 	// validate OTEL_EXPORTER_OTLP_PROTOCOL / --protocol
 	{

--- a/otelcli/config.go
+++ b/otelcli/config.go
@@ -111,7 +111,7 @@ type Config struct {
 	BackgroundSkipParentPidCheck bool   `json:"background_skip_parent_pid_check"`
 
 	ExecCommandTimeout  string `json:"exec_command_timeout" env:"OTEL_CLI_EXEC_CMD_TIMEOUT"`
-	ExecTpDisableInject bool   `json:"exec_tp_disable_inject" env:"OTEL_CLI_EXEC_TP_DISALBE_INJECT"`
+	ExecTpDisableInject bool   `json:"exec_tp_disable_inject" env:"OTEL_CLI_EXEC_TP_DISABLE_INJECT"`
 
 	StatusCanaryCount    int    `json:"status_canary_count"`
 	StatusCanaryInterval string `json:"status_canary_interval"`


### PR DESCRIPTION
Also adds a test I thought about but didn't write for 0.4.3.