### PR TITLE
fix exec span attrs (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 ## [0.4.5] - 2024-01-01
 
-Cleaning up warnings, dead code, and updating dependencies. No user-visible
-changes.
+Fix exec attributes, cleanups, and dependency updates.
+
+`otel-cli exec` attributes were broken for the last few releases so @tobert
+felt it was ok to rename them to match the OTel semantic conventions
+now.
+
+### Changed
+
+- using latest deps for grpc, protobuf, and otel
+- exec attributes will now go out with the span
+- exec now sends process.command and process.command_args attributes
+- main_test.go now supports regular expression tests on span data
 
 ## [0.4.4] - 2024-03-11
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ brew tap equinix-labs/otel-cli
 brew install otel-cli
 ```
 
-
 Alternatively, clone the repo and build it locally:
 
 ```shell

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -548,6 +548,23 @@ var suites = []FixtureSuite{
 				Config:        otelcli.DefaultConfig().WithEndpoint("grpc://{{endpoint}}"),
 			},
 		},
+		{
+			Name: "#316 ensure process command and args are sent as attributes",
+			Config: FixtureConfig{
+				CliArgs: []string{"exec",
+					"--endpoint", "{{endpoint}}",
+					"--verbose", "--fail",
+					"--", "/bin/echo", "a", "z",
+				},
+			},
+			Expect: Results{
+				SpanCount: 1,
+				CliOutput: "a z\n",
+				SpanData: map[string]string{
+					"attributes": "process.command=/bin/echo,process.command_args=/bin/echo,a,z",
+				},
+			},
+		},
 	},
 	// otel-cli span with no OTLP config should do and print nothing
 	{

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -554,6 +554,7 @@ var suites = []FixtureSuite{
 				CliArgs: []string{"exec",
 					"--endpoint", "{{endpoint}}",
 					"--verbose", "--fail",
+					"--attrs", "zy=ab", // ensure CLI args still propagate
 					"--", "/bin/echo", "a", "z",
 				},
 			},
@@ -561,7 +562,7 @@ var suites = []FixtureSuite{
 				SpanCount: 1,
 				CliOutput: "a z\n",
 				SpanData: map[string]string{
-					"attributes": "process.command=/bin/echo,process.command_args=/bin/echo,a,z",
+					"attributes": "/^process.command=/bin/echo,process.command_args=/bin/echo,a,z,process.owner=\\w+,process.parent_pid=\\d+,process.pid=\\d+,zy=ab/",
 				},
 			},
 		},

--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"os/user"
 	"strings"
 	"time"
 
@@ -61,26 +62,7 @@ func doExec(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	config := getConfig(ctx)
 	span := config.NewProtobufSpan()
-
-	// https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/
-	span.Attributes = []*commonpb.KeyValue{
-		{
-			Key: "process.command",
-			Value: &commonpb.AnyValue{
-				Value: &commonpb.AnyValue_StringValue{StringValue: args[0]},
-			},
-		},
-		{ // will be overwritten if there are arguments
-			Key: "process.command_args",
-			Value: &commonpb.AnyValue{
-				Value: &commonpb.AnyValue_ArrayValue{
-					ArrayValue: &commonpb.ArrayValue{
-						Values: []*commonpb.AnyValue{},
-					},
-				},
-			},
-		},
-	}
+	processAttrs := processArgAttrs(args) // might be overwritten in process setup
 
 	// no deadline if there is no command timeout set
 	cancelCtxDeadline := func() {}
@@ -119,30 +101,9 @@ func doExec(cmd *cobra.Command, args []string) {
 			for i, arg := range args[1:] {
 				tpArgs[i] = strings.Replace(arg, "{{traceparent}}", tp.Encode(), -1)
 			}
-		}
 
-		// convert args to an OpenTelemetry string list
-		// https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/
-		avlist := make([]*commonpb.AnyValue, len(tpArgs)+1)
-		avlist[0] = &commonpb.AnyValue{
-			Value: &commonpb.AnyValue_StringValue{
-				StringValue: args[0],
-			},
-		}
-		for i, v := range tpArgs {
-			sv := commonpb.AnyValue_StringValue{StringValue: v}
-			av := commonpb.AnyValue{Value: &sv}
-			avlist[i+1] = &av
-		}
-		span.Attributes[1] = &commonpb.KeyValue{
-			Key: "process.command_args",
-			Value: &commonpb.AnyValue{
-				Value: &commonpb.AnyValue_ArrayValue{
-					ArrayValue: &commonpb.ArrayValue{
-						Values: avlist,
-					},
-				},
-			},
+			// overwrite process args attributes with the injected values
+			processAttrs = processArgAttrs(append([]string{args[0]}, tpArgs...))
 		}
 
 		child = exec.CommandContext(cmdCtx, args[0], tpArgs...)
@@ -183,6 +144,11 @@ func doExec(cmd *cobra.Command, args []string) {
 	}
 	span.EndTimeUnixNano = uint64(time.Now().UnixNano())
 
+	// append process attributes
+	span.Attributes = append(span.Attributes, processAttrs...)
+	pidAttrs := processPidAttrs(config, int64(child.Process.Pid), int64(os.Getpid()))
+	span.Attributes = append(span.Attributes, pidAttrs...)
+
 	cancelCtxDeadline()
 	close(signals)
 	<-signalsDone
@@ -206,4 +172,64 @@ func doExec(cmd *cobra.Command, args []string) {
 	Diag.ExecExitCode = child.ProcessState.ExitCode()
 
 	config.PropagateTraceparent(span, os.Stdout)
+}
+
+// processArgAttrs turns the provided args list into OTel attributes
+// that can be appended to a protobuf span's span.Attributes.
+// https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/
+func processArgAttrs(args []string) []*commonpb.KeyValue {
+	// convert args to an OpenTelemetry string list
+	avlist := make([]*commonpb.AnyValue, len(args))
+	for i, v := range args {
+		sv := commonpb.AnyValue_StringValue{StringValue: v}
+		av := commonpb.AnyValue{Value: &sv}
+		avlist[i] = &av
+	}
+
+	return []*commonpb.KeyValue{
+		{
+			Key: "process.command",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_StringValue{StringValue: args[0]},
+			},
+		},
+		{
+			Key: "process.command_args",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_ArrayValue{
+					ArrayValue: &commonpb.ArrayValue{
+						Values: avlist,
+					},
+				},
+			},
+		},
+	}
+}
+
+// processPidAttrs returns process.{owner,pid,parent_pid} attributes ready
+// to append to a protobuf span's span.Attributes.
+func processPidAttrs(config Config, ppid, pid int64) []*commonpb.KeyValue {
+	user, err := user.Current()
+	config.SoftLogIfErr(err)
+
+	return []*commonpb.KeyValue{
+		{
+			Key: "process.owner",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_StringValue{StringValue: user.Username},
+			},
+		},
+		{
+			Key: "process.pid",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_IntValue{IntValue: pid},
+			},
+		},
+		{
+			Key: "process.parent_pid",
+			Value: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_IntValue{IntValue: ppid},
+			},
+		},
+	}
 }

--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -64,13 +64,13 @@ func doExec(cmd *cobra.Command, args []string) {
 
 	// https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/
 	span.Attributes = []*commonpb.KeyValue{
-		&commonpb.KeyValue{
+		{
 			Key: "process.command",
 			Value: &commonpb.AnyValue{
 				Value: &commonpb.AnyValue_StringValue{StringValue: args[0]},
 			},
 		},
-		&commonpb.KeyValue{ // will be overwritten if there are arguments
+		{ // will be overwritten if there are arguments
 			Key: "process.command_args",
 			Value: &commonpb.AnyValue{
 				Value: &commonpb.AnyValue_ArrayValue{


### PR DESCRIPTION
During previous refactors of exec for other things, the span creation got moved to the top of the function, and then later code would manipulate config.Attributes, which no longer got picked up.

Regression test added for https://github.com/equinix-labs/otel-cli/issues/316.

Since this functionality was broken for a bit, the attributes are being renamed along the way to match the OTel semantic specs.

Attributes are built up manually in protobuf structs because the helpers don't support array values. This could move to a helper later but seems fine as-is.