### PR TITLE
remove unnecessary RUN layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:latest AS builder
 
-RUN mkdir /build
 WORKDIR /build
 COPY . .
 ENV CGO_ENABLED=0


### PR DESCRIPTION
`WORKDIR` creates the directory automatically anyway, so we don't need to do it ourselves.

https://docs.docker.com/reference/dockerfile/#workdir