### PR TITLE
strip debug symbols from built binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /build
 WORKDIR /build
 COPY . .
 ENV CGO_ENABLED=0
-RUN go build -o otel-cli .
+RUN go build -ldflags="-w -s" -o otel-cli .
 
 FROM scratch AS otel-cli
 


### PR DESCRIPTION
We don't need these symbols when running in production, so removing them slims down the compiled binary a bit.