### PR TITLE
build smaller binaries, add version subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       # otel-cli's main test needs the binary built ahead of time
       # also this validates it can acutally build before we get there
       - name: Build
-        run: go build -v
+        # build with -s -w to reduce binary size and verify that build in test
+        run: go build -v -ldflags="-s -w -X main.version=test -X main.commit=${{ github.sha }}"
       - name: Test
         run: go test -v ./...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,9 @@ builds:
         goarch: 386
       - goos: freebsd
         goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{ .CommitDate }}
 
 nfpms:
   - package_name: otel-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.4.6] - 2024-05-13
+
+Build smaller binaries and add version subcommand.
+
+### Added
+
+- `otel-cli version` will now report version information of the binary (if any)
+
+### Changed
+
+- linker flags now contain `-s -w` to reduce binary size
+   - change made in build Dockerfile, goreleaser, and GH Actions
+   - contribution from @Ipmi-13, thank you!
+- goreleaser now does the -X flags so `otel-cli version` will work right
+
 ## [0.4.5] - 2024-01-01
 
 Fix exec attributes, cleanups, and dependency updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Build smaller binaries and add version subcommand.
    - change made in build Dockerfile, goreleaser, and GH Actions
    - contribution from @Ipmi-13, thank you!
 - goreleaser now does the -X flags so `otel-cli version` will work right
+- removed Content-Length from functional tests bc it's not fixed with gzip in play
 
 ## [0.4.5] - 2024-01-01
 

--- a/data_for_test.go
+++ b/data_for_test.go
@@ -1302,7 +1302,6 @@ var suites = []FixtureSuite{
 					"Content-Type":                "application/x-protobuf",
 					"Accept-Encoding":             "gzip",
 					"User-Agent":                  "Go-http-client/1.1",
-					"Content-Length":              "232",
 					"X-Otel-Cli-Otlpserver-Token": "abcdefgabcdefg",
 				},
 				Diagnostics: otelcli.Diagnostics{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 toolchain go1.21.1
 
 require (
-	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.6.0
 	github.com/pterm/pterm v0.12.79
 	github.com/spf13/cobra v1.8.0
@@ -24,6 +23,7 @@ require (
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -345,6 +345,12 @@ func checkSpanData(t *testing.T, fixture Fixture, results Results) {
 
 // checkHeaders compares the expected and received headers.
 func checkHeaders(t *testing.T, fixture Fixture, results Results) {
+	// gzip encoding makes automatically comparing values tricky, so ignore it
+	// unless the test actually specifies a length
+	if _, ok := fixture.Expect.Headers["Content-Length"]; !ok {
+		delete(results.Headers, "Content-Length")
+	}
+
 	injectMapVars(fixture.Endpoint, fixture.Expect.Headers, fixture.TlsData)
 	injectMapVars(fixture.Endpoint, results.Headers, fixture.TlsData)
 

--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -71,6 +71,7 @@ func createRootCmd(config *Config) *cobra.Command {
 	rootCmd.AddCommand(execCmd(config))
 	rootCmd.AddCommand(statusCmd(config))
 	rootCmd.AddCommand(serverCmd(config))
+	rootCmd.AddCommand(versionCmd(config))
 	rootCmd.AddCommand(completionCmd(config))
 
 	return rootCmd

--- a/otelcli/version.go
+++ b/otelcli/version.go
@@ -1,6 +1,29 @@
 package otelcli
 
-import "strings"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd prints the version and exits.
+func versionCmd(_ *Config) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "version",
+		Short: "print otel-cli's version, commit, release date to stdout",
+		Run:   doVersion,
+	}
+
+	return &cmd
+}
+
+func doVersion(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	config := getConfig(ctx)
+	fmt.Fprintln(os.Stdout, config.Version)
+}
 
 // FormatVersion pretty-prints the global version, commit, and date values into
 // a string to enable the --version flag. Public to be called from main.


### PR DESCRIPTION
A PR came in to add -s -w to build ldflags, which will reduce binary sizes. Since the PR only updated /Dockerfile, these will only impact locally-built binaries.

This PR adds the flags to goreleaser and github actions builds to be consistent.

Along the way I noticed that I never exposed the version information in otel-cli, so I added that too.