### PR TITLE
example: otel-wrapper-shim.sh + symlinks to trace nodejs builds

### DIFF
--- a/demos/30-trace-build-process/bash
+++ b/demos/30-trace-build-process/bash
@@ -1,0 +1,1 @@
+otel-wrapper-shim.sh

--- a/demos/30-trace-build-process/otel-wrapper-shim.sh
+++ b/demos/30-trace-build-process/otel-wrapper-shim.sh
@@ -18,8 +18,8 @@
 #
 # For more complex build processes, I have found jaeger to be quite good, because it also includes
 # a black "critical path line". See https://www.jaegertracing.io/docs/1.54/getting-started/ for
-# their all-in-one docker conainer setup instructions. Otherwise, everything else sis the same as
-# when using otel-desktop-viewer
+# their all-in-one docker conainer setup instructions. Otherwise, everything else is the same as
+# when using otel-desktop-viewer.
 
 set -euo pipefail
 

--- a/demos/30-trace-build-process/otel-wrapper-shim.sh
+++ b/demos/30-trace-build-process/otel-wrapper-shim.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Build Process Tracing Example
+#
+# It's possible to instrument complex build processes in nodejs (npm/yarn/pnpm) and
+# C (make/cmake/ninja) by injecting instrumented versions of some key commands into $PATH.
+#
+# This example is a folder with a shim script in it, and a bunch of fake tools that are just
+# symlinks to the shim. It needs to be a folder so that it can be cleanly injected into $PATH.
+#
+# To see this working, start `otel-desktop-viewer` as discribed in the main README.md, and then:
+# (
+#   cd .. && \
+#   ([ -d mermaid ] || git clone https://github.com/mermaid-js/mermaid) && \
+#   cd mermaid/ && \
+#   ../otel-cli/demos/30-trace-build-process/pnpm install
+# )
+#
+# For more complex build processes, I have found jaeger to be quite good, because it also includes
+# a black "critical path line". See https://www.jaegertracing.io/docs/1.54/getting-started/ for
+# their all-in-one docker conainer setup instructions. Otherwise, everything else sis the same as
+# when using otel-desktop-viewer
+
+set -euo pipefail
+
+export OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-localhost:4317}"
+
+TOOL_NAME="$(basename $0)"
+LOCATION_IN_PATH="$(dirname $0)"
+HERE="$(dirname $(readlink -f $0))"
+# This is just a guess, based on what's left after we've removed ourselves and any symlinks we know about from the results.
+# If we're symlinked into $PATH in more than once place then we could still end up in loops.
+# If this becomes a problem, we could instead iterate over each location and call readlink,
+# and drop anything that resolves to $HERE.
+ORIGINAL_TOOL_PATH="$(which -a "$TOOL_NAME" | grep -Ev "($HERE|$LOCATION_IN_PATH)" | head -n1)"
+
+# Put this dir first in $PATH so that nested calls out to bash and pnpm are instrumented
+# (tools like npm have a habit of messing with $PATH to put themselves first in subshells).
+# This will probably get quite long if there is a lot of recursion.
+# If this causes problems, we could prune ouselves out before inserting ourself at the head.
+export PATH="$HERE:$PATH"
+
+otel-cli exec --service "$TOOL_NAME" --name "$*" -- $ORIGINAL_TOOL_PATH "$@"

--- a/demos/30-trace-build-process/pnpm
+++ b/demos/30-trace-build-process/pnpm
@@ -1,0 +1,1 @@
+otel-wrapper-shim.sh

--- a/demos/30-trace-build-process/sh
+++ b/demos/30-trace-build-process/sh
@@ -1,0 +1,1 @@
+otel-wrapper-shim.sh

--- a/demos/30-trace-build-process/tsx
+++ b/demos/30-trace-build-process/tsx
@@ -1,0 +1,1 @@
+otel-wrapper-shim.sh


### PR DESCRIPTION
I should start by saying that this project has been super-helpful to me at work. It fits with the unix philosophy beautifully and makes it easy to use distributed systems debugging tools for buildsystems.

I wrote something similar to the attached script at work, and managed to shave about 30s our build process (mostly by tweaking which build steps were run concurrently).

I've not actually tried using it for instrumenting C build systems, but that might be an interesting experiment.

I would also like to try installing an opentelemetry collector into github actions, and running everything using this shim. If anyone tries it, please report back ;-).

If people find it useful, it may be that this functionality could be included in the main otel-cli binary (if it detects that it's been symlinked into $PATH with a name other than otel-cli).

<img width="949" alt="Screenshot 2024-06-23 at 18 07 24" src="https://github.com/equinix-labs/otel-cli/assets/254647/97138016-3cb2-4447-a860-0f5f2f1b631c">