### PR TITLE
Fix quoted "otel-cli exec ..." example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
 otel-cli exec --service my-service --name "curl google" curl https://google.com
 
 # otel-cli propagates context via envvars so you can chain it to create child spans
-otel-cli exec --kind producer "otel-cli exec --kind consumer sleep 1"
+otel-cli exec --kind producer -- otel-cli exec --kind consumer sleep 1
 
 # if a traceparent envvar is set it will be automatically picked up and
 # used by span and exec. use --tp-ignore-env to ignore it even when present


### PR DESCRIPTION
This example from README:

    # otel-cli propagates context via envvars so you can chain it to create child spans
    otel-cli exec --kind producer "otel-cli exec --kind consumer sleep 1"

doesn't work, because we're running into #356.
It worked until `/bin/sh -c` was removed in #202.