### PR TITLE
feat: build artifacts for linux/riscv64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,6 +32,7 @@ builds:
       - amd64
       - arm64
       - 386
+      - riscv64
     goarm:
       - 7
     ignore:
@@ -107,14 +108,28 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64/v8"
+  - image_templates:
+    - "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}-riscv64"
+    dockerfile: release/Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/riscv64"
 
 docker_manifests:
   - name_template: "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}"
     image_templates:
     - "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}-amd64"
     - "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}-arm64v8"
+    - "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}-riscv64"
   - name_template: "ghcr.io/equinix-labs/otel-cli:latest"
     image_templates:
     - "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}-amd64"
     - "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}-arm64v8"
+    - "ghcr.io/equinix-labs/otel-cli:{{ .Tag }}-riscv64"
     use: docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest AS builder
+FROM golang:alpine AS builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
Adds binaries and OCI images for `linux/riscv64`.  
  
I also updated the dev `Dockerfile` base image to an `Alpine` based one, since the `Debian` variant doesn't support `riscv64` yet (I can undo that since it is only for development).

The binary builds fine for `linux/riscv64`, and I ran some basic tests using the Examples section in the README:
```sh
user@bananapif3:~/Projects/otel-cli$ file otel-cli
otel-cli: ELF 64-bit LSB executable, UCB RISC-V, double-float ABI, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, Go BuildID=qDSUKfORsyrmBCW3XEtB/qCwmlXpQTQzDKGxF6-tw/zFSA2FhsuaIA_9Rongb9/m0duPj5m4mBtPdQ_0L1p, with debug_info, not stripped

user@bananapif3:~/Projects/otel-cli$ ldd otel-cli
	linux-vdso.so.1 (0x0000003fad164000)
	libc.so.6 => /lib/riscv64-linux-gnu/libc.so.6 (0x0000003facff0000)
	/lib/ld-linux-riscv64-lp64d.so.1 (0x0000003fad166000)
	
user@bananapif3:~/Projects/otel-cli$ ./otel-cli server tui
Trace ID                         | Span ID          | Parent           | Name                             | Kind   | Start | End    | Elapsed
                                 | bab93bed0fbf60aa | b7ad6b7169203331 | todo-generate-default-span-names | client | 0     | 122877 | 122877
b5788a359ecd584d2e129464e9429d9c | 4a4b0482ef8d5ffc |                  | curl google                      | client | 0     | 370    | 370
``` 
   
   
Similarly the Docker image also builds fine:
```sh
user@bananapif3:~/Projects/otel-cli$ docker image inspect otel-cli:test | grep Arch
        "Architecture": "riscv64",
```