### PR TITLE
only set pidAttrs when child.Process is not nil

### DIFF
--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -146,8 +146,10 @@ func doExec(cmd *cobra.Command, args []string) {
 
 	// append process attributes
 	span.Attributes = append(span.Attributes, processAttrs...)
-	pidAttrs := processPidAttrs(config, int64(child.Process.Pid), int64(os.Getpid()))
-	span.Attributes = append(span.Attributes, pidAttrs...)
+	if child.Process != nil {
+		pidAttrs := processPidAttrs(config, int64(child.Process.Pid), int64(os.Getpid()))
+		span.Attributes = append(span.Attributes, pidAttrs...)
+	}
 
 	cancelCtxDeadline()
 	close(signals)


### PR DESCRIPTION
I'm observing a crash with the following example program:

`otel-cli exec 'echo moo'`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x97819b]

goroutine 1 [running]:
github.com/equinix-labs/otel-cli/otelcli.doExec(0xc000200f00?, {0xc0002b7220, 0x1, 0xa})
        /home/atobey/src/otel-cli/otelcli/exec.go:149 +0x109b
github.com/spf13/cobra.(*Command).execute(0xc0002a8900, {0xc0002b70e0, 0xa, 0xa})
        /home/atobey/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0xc000005800)
        /home/atobey/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/atobey/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /home/atobey/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1032
github.com/equinix-labs/otel-cli/otelcli.Execute({0xc00003c4b0, 0x43})
        /home/atobey/src/otel-cli/otelcli/root.go:89 +0x188
main.main()
        /home/atobey/src/otel-cli/main.go:17 +0x45
```

This is mean to create a subprocess that sets TRACEPARENT such that the subprocess propagates the trace and the subprocess appears as a child.

FWIW, this works ok:

```
otel-cli exec echo moo
```

I built the project from source with a debugger, and found that with these arguments, the child.Process object is nil. I don't know if this is a bug, or if I'm just doing things wrong. Feel free to close this PR if I'm just doing things wrong, or if my approach will have unanticipated consequences.