### PR TITLE
support grpc reflection

### DIFF
--- a/otlpserver/grpcserver.go
+++ b/otlpserver/grpcserver.go
@@ -12,6 +12,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/reflection"
 )
 
 // GrpcServer is a gRPC/OTLP server handle.
@@ -36,6 +37,8 @@ func NewGrpcServer(cb Callback, stop Stopper) *GrpcServer {
 	}
 
 	coltracepb.RegisterTraceServiceServer(s.server, &s)
+
+	reflection.Register(s.server)
 
 	// single place to stop the server, used by timeout and max-spans
 	go func() {


### PR DESCRIPTION
This enables support for [gRPC reflection](https://grpc.io/docs/guides/reflection/).

When running `otel-cli server tui` in one terminal, from another, use [grpCurl](https://github.com/fullstorydev/grpcurl) to query the otel-cli endpoint at `localhost:4317`

```
» grpcurl -plaintext localhost:4317 list
grpc.reflection.v1.ServerReflection
grpc.reflection.v1alpha.ServerReflection
opentelemetry.proto.collector.trace.v1.TraceService
```

without this, an error is received:
```
Failed to dial target host "localhost:4317": dial tcp [::1]:4317: connect: connection refused
```